### PR TITLE
[M140] feat: enable Quad9 option for DNS over HTTPS

### DIFF
--- a/patches/helium/settings/quad9-doh-enable.patch
+++ b/patches/helium/settings/quad9-doh-enable.patch
@@ -1,0 +1,11 @@
+--- a/net/dns/public/doh_provider_entry.cc
++++ b/net/dns/public/doh_provider_entry.cc
+@@ -252,7 +252,7 @@ const DohProviderEntry::List& DohProvide
+         LoggingLevel::kNormal},
+        {"Quad9Secure",
+         MAKE_BASE_FEATURE_WITH_STATIC_STORAGE(
+-            DohProviderQuad9Secure, base::FEATURE_DISABLED_BY_DEFAULT),
++            DohProviderQuad9Secure, base::FEATURE_ENABLED_BY_DEFAULT),
+         {"9.9.9.9", "149.112.112.112", "2620:fe::fe", "2620:fe::9"},
+         /*dns_over_tls_hostnames=*/{"dns.quad9.net", "dns9.quad9.net"},
+         "https://dns.quad9.net/dns-query",

--- a/patches/series
+++ b/patches/series
@@ -177,6 +177,7 @@ helium/settings/fix-text-on-cookies-page.patch
 helium/settings/update-search-suggest-text.patch
 helium/settings/fix-appearance-page.patch
 helium/settings/remove-dead-imports.patch
+helium/settings/quad9-doh-enable.patch
 
 helium/hop/setup.patch
 helium/hop/disable-password-manager.patch


### PR DESCRIPTION
For your pull request to not get closed without review, please confirm that:

- [X] An issue exists where the maintainers agreed that this should be implemented.
      If such issue did not exist before, I opened one.
- [X] I tested that my contribution works locally, and does not break anything,
      otherwise I have marked my PR as draft.
- [X] If my contribution is non-trivial, I did not use AI to write most of it.
- [x] I understand that I will be permanently banned from interacting with this
      organization if I lied by checking any of these checkboxes.

Tested on (check one or more):
- [ ] Windows
- [X] macOS
- [ ] Linux

---

Enables the option to select Quad9 DNS from the secure DNS settings page and use Quad9 DNS-over-HTTPS if the setting in Helium is set to use the "OS option if supported" and Quad9 is the system's DNS. Fixes #178.

I'm willing to wait to rebase this off of M141 when that gets merged if that's preferred.
