### PR TITLE
feat: add --version and -v flags to display Helium version

### DIFF
--- a/patches/helium/core/modify-version-output.patch
+++ b/patches/helium/core/modify-version-output.patch
@@ -1,0 +1,24 @@
+--- a/chrome/app/chrome_main.cc
++++ b/chrome/app/chrome_main.cc
+@@ -15,6 +15,7 @@
+ #include "base/command_line.h"
+ #include "base/debug/debugger.h"
+ #include "base/debug/stack_trace.h"
++#include "base/version_info/version_info.h"
+ #include "build/branding_buildflags.h"
+ #include "build/build_config.h"
+ #include "chrome/app/chrome_main_delegate.h"
+@@ -45,6 +46,12 @@ int ChromeMain(int argc, const char** argv) {
+   const base::CommandLine::CharType** argv_casted =
+       reinterpret_cast<const base::CommandLine::CharType**>(argv);
+ 
++  // Handle --version and -v flags to show Helium version instead of Chromium version
++  if (base::CommandLine::ForCurrentProcess()->HasSwitch("version") ||
++      base::CommandLine::ForCurrentProcess()->HasSwitch("v")) {
++    printf("Helium %s\n", version_info::GetHeliumVersionNumber().data());
++    return 0;
++  }
++
+   // Initialize logging after command line parsing, but before
+   // chrome_main_delegate is initialized so that chrome_main_delegate can
+   // configure logging if needed.

--- a/patches/series
+++ b/patches/series
@@ -139,6 +139,7 @@ helium/core/replace-default-profile-name.patch
 helium/core/disable-live-caption-completely.patch
 helium/core/spoof-extension-downloader-platform.patch
 helium/core/add-helium-versioning.patch
+helium/core/modify-version-output.patch
 helium/core/enable-tab-search-toolbar-button.patch
 helium/core/hide-avatar-via-toolbar-prefs.patch
 helium/core/hide-extensions-via-toolbar-prefs.patch


### PR DESCRIPTION
For your pull request to not get closed without review, please confirm that:

- [x] An issue exists where the maintainers agreed that this should be implemented.
      If such issue did not exist before, I opened one.
- [ ] I tested that my contribution works locally, and does not break anything,
      otherwise I have marked my PR as draft.
- [ ] If my contribution is non-trivial, I did not use AI to write most of it.
- [x] I understand that I will be permanently banned from interacting with this
      organization if I lied by checking any of these checkboxes.

Tested on (check one or more):
- [ ] Windows
- [ ] macOS
- [ ] Linux

---

Add --version and -v flags to display Helium version instead of Chromium version

- Modified chrome_main.cc to intercept --version and -v command line flags
- Uses existing GetHeliumVersionNumber() function from add-helium-versioning.patch
- Closes #193 
- Added modify-version-output.patch to patches/series for proper application order
