### PR TITLE
helium/ui/tabs: fix tab groups ui

### DIFF
--- a/patches/helium/ui/tabs.patch
+++ b/patches/helium/ui/tabs.patch
@@ -72,6 +72,15 @@
      float top_left_corner_radius = content_corner_radius;
      float top_right_corner_radius = content_corner_radius;
      float bottom_left_corner_radius = content_corner_radius;
+@@ -839,6 +833,8 @@ float TabStyleViewsImpl::GetHoverOpacity
+ }
+ 
+ int TabStyleViewsImpl::GetStrokeThickness(bool should_paint_as_active) const {
++  return 0;
++
+   std::optional<tab_groups::TabGroupId> group = tab_->group();
+   if (group.has_value() && tab_->IsActive()) {
+     return TabGroupUnderline::kStrokeThickness;
 --- a/chrome/browser/ui/views/tabs/tab.cc
 +++ b/chrome/browser/ui/views/tabs/tab.cc
 @@ -1164,7 +1164,7 @@ void Tab::UpdateIconVisibility() {
@@ -177,3 +186,53 @@
    ring_highlight_path->set_use_contents_bounds(true);
    views::FocusRing::Get(this)->SetPathGenerator(std::move(ring_highlight_path));
  
+--- a/chrome/browser/ui/views/tabs/tab_group_style.cc
++++ b/chrome/browser/ui/views/tabs/tab_group_style.cc
+@@ -32,7 +32,7 @@ constexpr int kAttentionIndicatorWidth =
+ // The size of the empty chip.
+ constexpr int kEmptyChipSize = 20;
+ constexpr int kCornerRadius = 6;
+-constexpr int kTabGroupOverlapAdjustment = 2;
++constexpr int kTabGroupOverlapAdjustment = 3;
+ 
+ }  // namespace
+ 
+--- a/chrome/browser/ui/views/tabs/tab_group_underline.cc
++++ b/chrome/browser/ui/views/tabs/tab_group_underline.cc
+@@ -93,21 +93,17 @@ gfx::Insets TabGroupUnderline::GetInsets
+   // the group, and may be the right boundary if the group is collapsed.
+   const TabGroupHeader* const header =
+       views::AsViewClass<TabGroupHeader>(sibling_view);
++
++  const int left_offset = 3;
+   if (header) {
+-    return gfx::Insets::TLBR(0, TabGroupUnderline::GetStrokeInset(), 0,
+-                             TabGroupUnderline::GetStrokeInset());
++    return gfx::Insets::TLBR(0, TabGroupUnderline::GetStrokeInset() + left_offset,
++                            0, TabGroupUnderline::GetStrokeInset());
+   }
+ 
+   const Tab* const tab = views::AsViewClass<Tab>(sibling_view);
+   DCHECK(tab);
+ 
+-  // Active tabs need the rounded bits of the underline poking out the sides.
+-  if (tab->IsActive()) {
+-    return gfx::Insets::TLBR(0, -kStrokeThickness, 0, -kStrokeThickness);
+-  }
+-
+-  // Inactive tabs are inset like group headers.
+-  const int left_inset = TabGroupUnderline::GetStrokeInset();
++  const int left_inset = TabGroupUnderline::GetStrokeInset() + left_offset;
+   const int right_inset = TabGroupUnderline::GetStrokeInset();
+ 
+   return gfx::Insets::TLBR(0, left_inset, 0, right_inset);
+@@ -119,8 +115,7 @@ void TabGroupUnderline::MaybeSetVisible(
+ 
+ // static
+ int TabGroupUnderline::GetStrokeInset() {
+-  return TabStyle::Get()->GetTabOverlap() -
+-         TabGroupStyle::GetTabGroupOverlapAdjustment() + kStrokeThickness;
++  return TabStyle::Get()->GetTabOverlap() - 7 + kStrokeThickness;
+ }
+ 
+ BEGIN_METADATA(TabGroupUnderline)


### PR DESCRIPTION
- tabs no longer have a stroke when they're in a tab group
- the line under the tab group no longer jumps in size depending on a selected tab and is properly aligned

before:

https://github.com/user-attachments/assets/63ab023a-8549-4ece-9258-8a0bfa7b49cc

after:

https://github.com/user-attachments/assets/435fa8ae-e28e-4de3-9cab-8f59927d800b


