### PR TITLE
helium/ui: match Chrome tab group colors for better contrast

### DIFF
--- a/patches/helium/ui/disable-tab-group-editor-footer.patch
+++ b/patches/helium/ui/disable-tab-group-editor-footer.patch
@@ -1,5 +1,7 @@
---- a/chrome/browser/ui/views/tabs/groups/tab_group_editor_bubble_view.cc
-+++ b/chrome/browser/ui/views/tabs/groups/tab_group_editor_bubble_view.cc
+Index: src/chrome/browser/ui/views/tabs/groups/tab_group_editor_bubble_view.cc
+===================================================================
+--- src.orig/chrome/browser/ui/views/tabs/groups/tab_group_editor_bubble_view.cc
++++ src/chrome/browser/ui/views/tabs/groups/tab_group_editor_bubble_view.cc
 @@ -138,9 +138,6 @@ constexpr int kSeparatorPadding = 8;
  constexpr int kDialogWidth = 240;
  // The default size of icons that are displayed in the tab group editor bubble.

--- a/patches/helium/ui/helium-color-mixers.patch
+++ b/patches/helium/ui/helium-color-mixers.patch
@@ -1,5 +1,7 @@
---- a/chrome/browser/ui/color/material_chrome_color_mixer.cc
-+++ b/chrome/browser/ui/color/material_chrome_color_mixer.cc
+Index: src/chrome/browser/ui/color/material_chrome_color_mixer.cc
+===================================================================
+--- src.orig/chrome/browser/ui/color/material_chrome_color_mixer.cc
++++ src/chrome/browser/ui/color/material_chrome_color_mixer.cc
 @@ -50,6 +50,9 @@ void ApplyDefaultChromeRefreshToolbarCol
  
  void AddMaterialChromeColorMixer(ui::ColorProvider* provider,
@@ -45,9 +47,73 @@
    mixer[kColorToolbarText] = {kColorToolbarTextDefault};
    mixer[kColorToolbarTextDefault] = {ui::kColorSysOnSurfaceSecondary};
    mixer[kColorToolbarTextDisabled] = {kColorToolbarTextDisabledDefault};
---- a/chrome/browser/ui/color/chrome_color_mixer.cc
-+++ b/chrome/browser/ui/color/chrome_color_mixer.cc
-@@ -117,9 +117,13 @@ ui::ColorTransform GetToolbarTopSeparato
+Index: src/chrome/browser/ui/color/chrome_color_mixer.cc
+===================================================================
+--- src.orig/chrome/browser/ui/color/chrome_color_mixer.cc
++++ src/chrome/browser/ui/color/chrome_color_mixer.cc
+@@ -27,6 +27,61 @@
+ 
+ namespace {
+ 
++namespace chrome_tab_group_colors {
++
++constexpr SkColor kBlue050 = SkColorSetRGB(0xE8, 0xF0, 0xFE);
++constexpr SkColor kBlue100 = SkColorSetRGB(0xD2, 0xE3, 0xFC);
++constexpr SkColor kBlue300 = SkColorSetRGB(0x8A, 0xB4, 0xF8);
++constexpr SkColor kBlue600 = SkColorSetRGB(0x1A, 0x73, 0xE8);
++constexpr SkColor kBlue700 = SkColorSetRGB(0x19, 0x67, 0xD2);
++
++constexpr SkColor kRed050 = SkColorSetRGB(0xFC, 0xE8, 0xE6);
++constexpr SkColor kRed100 = SkColorSetRGB(0xFA, 0xD2, 0xCF);
++constexpr SkColor kRed300 = SkColorSetRGB(0xF2, 0x8B, 0x82);
++constexpr SkColor kRed600 = SkColorSetRGB(0xD9, 0x30, 0x25);
++constexpr SkColor kRed700 = SkColorSetRGB(0xC5, 0x22, 0x1F);
++
++constexpr SkColor kYellow050 = SkColorSetRGB(0xFE, 0xF7, 0xE0);
++constexpr SkColor kYellow100 = SkColorSetRGB(0xFE, 0xEF, 0xC3);
++constexpr SkColor kYellow300 = SkColorSetRGB(0xFD, 0xD6, 0x63);
++constexpr SkColor kYellow600 = SkColorSetRGB(0xF9, 0xAB, 0x00);
++
++constexpr SkColor kGreen050 = SkColorSetRGB(0xE6, 0xF4, 0xEA);
++constexpr SkColor kGreen100 = SkColorSetRGB(0xCE, 0xEA, 0xD6);
++constexpr SkColor kGreen300 = SkColorSetRGB(0x81, 0xC9, 0x95);
++constexpr SkColor kGreen700 = SkColorSetRGB(0x18, 0x80, 0x38);
++constexpr SkColor kGreen800 = SkColorSetRGB(0x13, 0x73, 0x33);
++
++constexpr SkColor kGrey100 = SkColorSetRGB(0xF1, 0xF3, 0xF4);
++constexpr SkColor kGrey300 = SkColorSetRGB(0xDA, 0xDC, 0xE0);
++constexpr SkColor kGrey700 = SkColorSetRGB(0x5F, 0x63, 0x68);
++constexpr SkColor kGrey800 = SkColorSetRGB(0x3C, 0x40, 0x43);
++
++constexpr SkColor kOrange050 = SkColorSetRGB(0xFE, 0xEF, 0xE3);
++constexpr SkColor kOrange100 = SkColorSetRGB(0xFE, 0xDF, 0xC8);
++constexpr SkColor kOrange300 = SkColorSetRGB(0xFC, 0xAD, 0x70);
++constexpr SkColor kOrange400 = SkColorSetRGB(0xFA, 0x90, 0x3E);
++constexpr SkColor kOrange800 = SkColorSetRGB(0xC2, 0x64, 0x01);
++
++constexpr SkColor kPink050 = SkColorSetRGB(0xFD, 0xE7, 0xF3);
++constexpr SkColor kPink100 = SkColorSetRGB(0xFD, 0xCF, 0xE8);
++constexpr SkColor kPink300 = SkColorSetRGB(0xFF, 0x8B, 0xCB);
++constexpr SkColor kPink700 = SkColorSetRGB(0xD0, 0x18, 0x84);
++constexpr SkColor kPink800 = SkColorSetRGB(0xB8, 0x06, 0x72);
++
++constexpr SkColor kPurple050 = SkColorSetRGB(0xF3, 0xE8, 0xFD);
++constexpr SkColor kPurple100 = SkColorSetRGB(0xE9, 0xD2, 0xFD);
++constexpr SkColor kPurple300 = SkColorSetRGB(0xC5, 0x8A, 0xF9);
++constexpr SkColor kPurple500 = SkColorSetRGB(0xA1, 0x42, 0xF4);
++constexpr SkColor kPurple700 = SkColorSetRGB(0x84, 0x30, 0xCE);
++
++constexpr SkColor kCyan050 = SkColorSetRGB(0xE4, 0xF7, 0xFB);
++constexpr SkColor kCyan100 = SkColorSetRGB(0xCB, 0xF0, 0xF8);
++constexpr SkColor kCyan300 = SkColorSetRGB(0x78, 0xD9, 0xEC);
++constexpr SkColor kCyan900 = SkColorSetRGB(0x00, 0x7B, 0x83);
++
++}  // namespace chrome_tab_group_colors
++
+ // This differs from ui::SelectColorBasedOnInput in that we're checking if the
+ // input transform is *not* dark under the assumption that the background color
+ // *is* dark from a potential custom theme. Additionally, if the mode is
+@@ -117,9 +172,13 @@ ui::ColorTransform GetToolbarTopSeparato
  // Apply updates to the Omnibox background color tokens per GM3 spec.
  void ApplyGM3OmniboxBackgroundColor(ui::ColorMixer& mixer,
                                      const ui::ColorProviderKey& key) {
@@ -62,7 +128,340 @@
      mixer[kColorLocationBarBackgroundHovered] =
          ui::GetResultingPaintColor(ui::kColorSysStateHoverBrightBlendProtection,
                                     kColorLocationBarBackground);
-@@ -810,8 +814,10 @@ void AddChromeColorMixer(ui::ColorProvid
+@@ -135,6 +194,7 @@ void AddChromeColorMixer(ui::ColorProvid
+                          const ui::ColorProviderKey& key) {
+   const bool dark_mode =
+       key.color_mode == ui::ColorProviderKey::ColorMode::kDark;
++  namespace tg = chrome_tab_group_colors;
+   ui::ColorMixer& mixer = provider->AddMixer();
+ 
+   mixer[kColorActorUiHandoffButtonBorder] =
+@@ -516,168 +576,119 @@ void AddChromeColorMixer(ui::ColorProvid
+   mixer[kColorSharingRecentActivityDialogFaviconContainer] = {
+       ui::kColorSysSurface};
+ 
+-  mixer[kColorTabGroupTabStripFrameActiveBlue] =
+-      ui::SelectBasedOnDarkInput(kColorTabBackgroundInactiveFrameActive,
+-                                 gfx::kGoogleBlue300, gfx::kGoogleBlue600);
+-  mixer[kColorTabGroupTabStripFrameActiveCyan] =
+-      ui::SelectBasedOnDarkInput(kColorTabBackgroundInactiveFrameActive,
+-                                 gfx::kGoogleCyan300, gfx::kGoogleCyan900);
+-  mixer[kColorTabGroupTabStripFrameActiveGreen] =
+-      ui::SelectBasedOnDarkInput(kColorTabBackgroundInactiveFrameActive,
+-                                 gfx::kGoogleGreen300, gfx::kGoogleGreen700);
+-  mixer[kColorTabGroupTabStripFrameActiveGrey] =
+-      ui::SelectBasedOnDarkInput(kColorTabBackgroundInactiveFrameActive,
+-                                 gfx::kGoogleGrey300, gfx::kGoogleGrey700);
+-  mixer[kColorTabGroupTabStripFrameActiveOrange] =
+-      ui::SelectBasedOnDarkInput(kColorTabBackgroundInactiveFrameActive,
+-                                 gfx::kGoogleOrange300, gfx::kGoogleOrange400);
+-  mixer[kColorTabGroupTabStripFrameActivePink] =
+-      ui::SelectBasedOnDarkInput(kColorTabBackgroundInactiveFrameActive,
+-                                 gfx::kGooglePink300, gfx::kGooglePink700);
+-  mixer[kColorTabGroupTabStripFrameActivePurple] =
+-      ui::SelectBasedOnDarkInput(kColorTabBackgroundInactiveFrameActive,
+-                                 gfx::kGooglePurple300, gfx::kGooglePurple500);
+-  mixer[kColorTabGroupTabStripFrameActiveRed] =
+-      ui::SelectBasedOnDarkInput(kColorTabBackgroundInactiveFrameActive,
+-                                 gfx::kGoogleRed300, gfx::kGoogleRed600);
+-  mixer[kColorTabGroupTabStripFrameActiveYellow] =
+-      ui::SelectBasedOnDarkInput(kColorTabBackgroundInactiveFrameActive,
+-                                 gfx::kGoogleYellow300, gfx::kGoogleYellow600);
+-
+-  mixer[kColorTabGroupTabStripFrameInactiveBlue] =
+-      ui::SelectBasedOnDarkInput(kColorTabBackgroundInactiveFrameInactive,
+-                                 gfx::kGoogleBlue300, gfx::kGoogleBlue600);
+-  mixer[kColorTabGroupTabStripFrameInactiveCyan] =
+-      ui::SelectBasedOnDarkInput(kColorTabBackgroundInactiveFrameInactive,
+-                                 gfx::kGoogleCyan300, gfx::kGoogleCyan900);
+-  mixer[kColorTabGroupTabStripFrameInactiveGreen] =
+-      ui::SelectBasedOnDarkInput(kColorTabBackgroundInactiveFrameInactive,
+-                                 gfx::kGoogleGreen300, gfx::kGoogleGreen700);
+-  mixer[kColorTabGroupTabStripFrameInactiveGrey] =
+-      ui::SelectBasedOnDarkInput(kColorTabBackgroundInactiveFrameInactive,
+-                                 gfx::kGoogleGrey300, gfx::kGoogleGrey700);
+-  mixer[kColorTabGroupTabStripFrameInactiveOrange] =
+-      ui::SelectBasedOnDarkInput(kColorTabBackgroundInactiveFrameInactive,
+-                                 gfx::kGoogleOrange300, gfx::kGoogleOrange400);
+-  mixer[kColorTabGroupTabStripFrameInactivePink] =
+-      ui::SelectBasedOnDarkInput(kColorTabBackgroundInactiveFrameInactive,
+-                                 gfx::kGooglePink300, gfx::kGooglePink700);
+-  mixer[kColorTabGroupTabStripFrameInactivePurple] =
+-      ui::SelectBasedOnDarkInput(kColorTabBackgroundInactiveFrameInactive,
+-                                 gfx::kGooglePurple300, gfx::kGooglePurple500);
+-  mixer[kColorTabGroupTabStripFrameInactiveRed] =
+-      ui::SelectBasedOnDarkInput(kColorTabBackgroundInactiveFrameInactive,
+-                                 gfx::kGoogleRed300, gfx::kGoogleRed600);
+-  mixer[kColorTabGroupTabStripFrameInactiveYellow] =
+-      ui::SelectBasedOnDarkInput(kColorTabBackgroundInactiveFrameInactive,
+-                                 gfx::kGoogleYellow300, gfx::kGoogleYellow600);
+-
+-  mixer[kColorTabGroupDialogBlue] = {kColorTabGroupContextMenuBlue};
+-  mixer[kColorTabGroupDialogCyan] = {kColorTabGroupContextMenuCyan};
+-  mixer[kColorTabGroupDialogGreen] = {kColorTabGroupContextMenuGreen};
+-  mixer[kColorTabGroupDialogGrey] = {kColorTabGroupContextMenuGrey};
+-  mixer[kColorTabGroupDialogOrange] = {kColorTabGroupContextMenuOrange};
+-  mixer[kColorTabGroupDialogPink] = {kColorTabGroupContextMenuPink};
+-  mixer[kColorTabGroupDialogPurple] = {kColorTabGroupContextMenuPurple};
+-  mixer[kColorTabGroupDialogRed] = {kColorTabGroupContextMenuRed};
+-  mixer[kColorTabGroupDialogYellow] = {kColorTabGroupContextMenuYellow};
++  mixer[kColorTabGroupTabStripFrameActiveBlue] = {tg::kBlue300};
++  mixer[kColorTabGroupTabStripFrameActiveCyan] = {tg::kCyan300};
++  mixer[kColorTabGroupTabStripFrameActiveGreen] = {tg::kGreen300};
++  mixer[kColorTabGroupTabStripFrameActiveGrey] = {tg::kGrey300};
++  mixer[kColorTabGroupTabStripFrameActiveOrange] = {tg::kOrange300};
++  mixer[kColorTabGroupTabStripFrameActivePink] = {tg::kPink300};
++  mixer[kColorTabGroupTabStripFrameActivePurple] = {tg::kPurple300};
++  mixer[kColorTabGroupTabStripFrameActiveRed] = {tg::kRed300};
++  mixer[kColorTabGroupTabStripFrameActiveYellow] = {tg::kYellow300};
++
++  mixer[kColorTabGroupTabStripFrameInactiveBlue] = {tg::kBlue300};
++  mixer[kColorTabGroupTabStripFrameInactiveCyan] = {tg::kCyan300};
++  mixer[kColorTabGroupTabStripFrameInactiveGreen] = {tg::kGreen300};
++  mixer[kColorTabGroupTabStripFrameInactiveGrey] = {tg::kGrey300};
++  mixer[kColorTabGroupTabStripFrameInactiveOrange] = {tg::kOrange300};
++  mixer[kColorTabGroupTabStripFrameInactivePink] = {tg::kPink300};
++  mixer[kColorTabGroupTabStripFrameInactivePurple] = {tg::kPurple300};
++  mixer[kColorTabGroupTabStripFrameInactiveRed] = {tg::kRed300};
++  mixer[kColorTabGroupTabStripFrameInactiveYellow] = {tg::kYellow300};
++
++  mixer[kColorTabGroupDialogBlue] = {tg::kBlue300};
++  mixer[kColorTabGroupDialogCyan] = {tg::kCyan300};
++  mixer[kColorTabGroupDialogGreen] = {tg::kGreen300};
++  mixer[kColorTabGroupDialogGrey] = {tg::kGrey300};
++  mixer[kColorTabGroupDialogOrange] = {tg::kOrange300};
++  mixer[kColorTabGroupDialogPink] = {tg::kPink300};
++  mixer[kColorTabGroupDialogPurple] = {tg::kPurple300};
++  mixer[kColorTabGroupDialogRed] = {tg::kRed300};
++  mixer[kColorTabGroupDialogYellow] = {tg::kYellow300};
+ 
+   mixer[kColorTabGroupContextMenuBlue] = SelectColorBasedOnDarkInputOrMode(
+-      dark_mode, kColorBookmarkBarForeground, gfx::kGoogleBlue300,
+-      gfx::kGoogleBlue600);
++      dark_mode, kColorBookmarkBarForeground, tg::kBlue300, tg::kBlue600);
+   mixer[kColorTabGroupContextMenuCyan] = SelectColorBasedOnDarkInputOrMode(
+-      dark_mode, kColorBookmarkBarForeground, gfx::kGoogleCyan300,
+-      gfx::kGoogleCyan900);
++      dark_mode, kColorBookmarkBarForeground, tg::kCyan300, tg::kCyan900);
+   mixer[kColorTabGroupContextMenuGreen] = SelectColorBasedOnDarkInputOrMode(
+-      dark_mode, kColorBookmarkBarForeground, gfx::kGoogleGreen300,
+-      gfx::kGoogleGreen700);
++      dark_mode, kColorBookmarkBarForeground, tg::kGreen300, tg::kGreen700);
+   mixer[kColorTabGroupContextMenuGrey] = SelectColorBasedOnDarkInputOrMode(
+-      dark_mode, kColorBookmarkBarForeground, gfx::kGoogleGrey300,
+-      gfx::kGoogleGrey700);
++      dark_mode, kColorBookmarkBarForeground, tg::kGrey300, tg::kGrey700);
+   mixer[kColorTabGroupContextMenuOrange] = SelectColorBasedOnDarkInputOrMode(
+-      dark_mode, kColorBookmarkBarForeground, gfx::kGoogleOrange300,
+-      gfx::kGoogleOrange400);
++      dark_mode, kColorBookmarkBarForeground, tg::kOrange300, tg::kOrange400);
+   mixer[kColorTabGroupContextMenuPink] = SelectColorBasedOnDarkInputOrMode(
+-      dark_mode, kColorBookmarkBarForeground, gfx::kGooglePink300,
+-      gfx::kGooglePink700);
++      dark_mode, kColorBookmarkBarForeground, tg::kPink300, tg::kPink700);
+   mixer[kColorTabGroupContextMenuPurple] = SelectColorBasedOnDarkInputOrMode(
+-      dark_mode, kColorBookmarkBarForeground, gfx::kGooglePurple300,
+-      gfx::kGooglePurple500);
+-  mixer[kColorTabGroupContextMenuRed] =
+-      SelectColorBasedOnDarkInputOrMode(dark_mode, kColorBookmarkBarForeground,
+-                                        gfx::kGoogleRed300, gfx::kGoogleRed600);
++      dark_mode, kColorBookmarkBarForeground, tg::kPurple300, tg::kPurple500);
++  mixer[kColorTabGroupContextMenuRed] = SelectColorBasedOnDarkInputOrMode(
++      dark_mode, kColorBookmarkBarForeground, tg::kRed300, tg::kRed600);
+   mixer[kColorTabGroupContextMenuYellow] = SelectColorBasedOnDarkInputOrMode(
+-      dark_mode, kColorBookmarkBarForeground, gfx::kGoogleYellow300,
+-      gfx::kGoogleYellow600);
++      dark_mode, kColorBookmarkBarForeground, tg::kYellow300, tg::kYellow600);
+ 
+   mixer[kColorSavedTabGroupForegroundBlue] = ui::SelectBasedOnDarkInput(
+-      kColorBookmarkBarBackground, gfx::kGoogleBlue100, gfx::kGoogleBlue700);
++      kColorBookmarkBarBackground, tg::kBlue100, tg::kBlue700);
+   mixer[kColorSavedTabGroupForegroundGrey] = ui::SelectBasedOnDarkInput(
+-      kColorBookmarkBarBackground, gfx::kGoogleGrey100, gfx::kGoogleGrey700);
++      kColorBookmarkBarBackground, tg::kGrey100, tg::kGrey700);
+   mixer[kColorSavedTabGroupForegroundRed] = ui::SelectBasedOnDarkInput(
+-      kColorBookmarkBarBackground, gfx::kGoogleRed100, gfx::kGoogleRed700);
++      kColorBookmarkBarBackground, tg::kRed100, tg::kRed700);
+   mixer[kColorSavedTabGroupForegroundGreen] = ui::SelectBasedOnDarkInput(
+-      kColorBookmarkBarBackground, gfx::kGoogleGreen100, gfx::kGoogleGreen800);
++      kColorBookmarkBarBackground, tg::kGreen100, tg::kGreen800);
+   mixer[kColorSavedTabGroupForegroundYellow] = ui::SelectBasedOnDarkInput(
+-      kColorBookmarkBarBackground, gfx::kGoogleYellow100, gfx::kGoogleGrey800);
++      kColorBookmarkBarBackground, tg::kYellow100, tg::kGrey800);
+   mixer[kColorSavedTabGroupForegroundCyan] = ui::SelectBasedOnDarkInput(
+-      kColorBookmarkBarBackground, gfx::kGoogleCyan100, gfx::kGoogleCyan900);
+-  mixer[kColorSavedTabGroupForegroundPurple] =
+-      ui::SelectBasedOnDarkInput(kColorBookmarkBarBackground,
+-                                 gfx::kGooglePurple100, gfx::kGooglePurple700);
++      kColorBookmarkBarBackground, tg::kCyan100, tg::kCyan900);
++  mixer[kColorSavedTabGroupForegroundPurple] = ui::SelectBasedOnDarkInput(
++      kColorBookmarkBarBackground, tg::kPurple100, tg::kPurple700);
+   mixer[kColorSavedTabGroupForegroundPink] = ui::SelectBasedOnDarkInput(
+-      kColorBookmarkBarBackground, gfx::kGooglePink100, gfx::kGooglePink800);
++      kColorBookmarkBarBackground, tg::kPink100, tg::kPink800);
+   mixer[kColorSavedTabGroupForegroundOrange] = ui::SelectBasedOnDarkInput(
+-      kColorBookmarkBarBackground, gfx::kGoogleOrange100, gfx::kGoogleGrey800);
++      kColorBookmarkBarBackground, tg::kOrange100, tg::kGrey800);
+ 
+   mixer[kColorSavedTabGroupOutlineBlue] = ui::SelectBasedOnDarkInput(
+-      kColorBookmarkBarBackground, gfx::kGoogleBlue300, gfx::kGoogleBlue700);
++      kColorBookmarkBarBackground, tg::kBlue300, tg::kBlue700);
+   mixer[kColorSavedTabGroupOutlineGrey] = ui::SelectBasedOnDarkInput(
+-      kColorBookmarkBarBackground, gfx::kGoogleGrey300, gfx::kGoogleGrey700);
++      kColorBookmarkBarBackground, tg::kGrey300, tg::kGrey700);
+   mixer[kColorSavedTabGroupOutlineRed] = ui::SelectBasedOnDarkInput(
+-      kColorBookmarkBarBackground, gfx::kGoogleRed300, gfx::kGoogleRed700);
++      kColorBookmarkBarBackground, tg::kRed300, tg::kRed700);
+   mixer[kColorSavedTabGroupOutlineGreen] = ui::SelectBasedOnDarkInput(
+-      kColorBookmarkBarBackground, gfx::kGoogleGreen300, gfx::kGoogleGreen800);
+-  mixer[kColorSavedTabGroupOutlineYellow] =
+-      ui::SelectBasedOnDarkInput(kColorBookmarkBarBackground,
+-                                 gfx::kGoogleYellow300, gfx::kGoogleYellow600);
++      kColorBookmarkBarBackground, tg::kGreen300, tg::kGreen800);
++  mixer[kColorSavedTabGroupOutlineYellow] = ui::SelectBasedOnDarkInput(
++      kColorBookmarkBarBackground, tg::kYellow300, tg::kYellow600);
+   mixer[kColorSavedTabGroupOutlineCyan] = ui::SelectBasedOnDarkInput(
+-      kColorBookmarkBarBackground, gfx::kGoogleCyan300, gfx::kGoogleCyan900);
+-  mixer[kColorSavedTabGroupOutlinePurple] =
+-      ui::SelectBasedOnDarkInput(kColorBookmarkBarBackground,
+-                                 gfx::kGooglePurple300, gfx::kGooglePurple700);
++      kColorBookmarkBarBackground, tg::kCyan300, tg::kCyan900);
++  mixer[kColorSavedTabGroupOutlinePurple] = ui::SelectBasedOnDarkInput(
++      kColorBookmarkBarBackground, tg::kPurple300, tg::kPurple700);
+   mixer[kColorSavedTabGroupOutlinePink] = ui::SelectBasedOnDarkInput(
+-      kColorBookmarkBarBackground, gfx::kGooglePink300, gfx::kGooglePink700);
+-  mixer[kColorSavedTabGroupOutlineOrange] =
++      kColorBookmarkBarBackground, tg::kPink300, tg::kPink700);
++  mixer[kColorSavedTabGroupOutlineOrange] = ui::SelectBasedOnDarkInput(
++      kColorBookmarkBarBackground, tg::kOrange300, tg::kOrange800);
++  mixer[kColorTabGroupBookmarkBarBlue] =
++      ui::SelectBasedOnDarkInput(kColorBookmarkBarBackground,
++                                 SkColorSetRGB(0x39, 0x43, 0x54), tg::kBlue050);
++  mixer[kColorTabGroupBookmarkBarCyan] =
+       ui::SelectBasedOnDarkInput(kColorBookmarkBarBackground,
+-                                 gfx::kGoogleOrange300, gfx::kGoogleOrange800);
+-  mixer[kColorTabGroupBookmarkBarBlue] = ui::SelectBasedOnDarkInput(
+-      kColorBookmarkBarBackground, SkColorSetRGB(0x39, 0x43, 0x54),
+-      gfx::kGoogleBlue050);
+-  mixer[kColorTabGroupBookmarkBarCyan] = ui::SelectBasedOnDarkInput(
+-      kColorBookmarkBarBackground, SkColorSetRGB(0x35, 0x4C, 0x51),
+-      gfx::kGoogleCyan050);
++                                 SkColorSetRGB(0x35, 0x4C, 0x51), tg::kCyan050);
+   mixer[kColorTabGroupBookmarkBarGreen] = ui::SelectBasedOnDarkInput(
+       kColorBookmarkBarBackground, SkColorSetRGB(0x37, 0x48, 0x3C),
+-      gfx::kGoogleGreen050);
+-  mixer[kColorTabGroupBookmarkBarGrey] = ui::SelectBasedOnDarkInput(
+-      kColorBookmarkBarBackground, SkColorSetRGB(0x4C, 0x4D, 0x4E),
+-      gfx::kGoogleGrey100);
+-  mixer[kColorTabGroupBookmarkBarPink] = ui::SelectBasedOnDarkInput(
+-      kColorBookmarkBarBackground, SkColorSetRGB(0x55, 0x39, 0x49),
+-      gfx::kGooglePink050);
++      tg::kGreen050);
++  mixer[kColorTabGroupBookmarkBarGrey] =
++      ui::SelectBasedOnDarkInput(kColorBookmarkBarBackground,
++                                 SkColorSetRGB(0x4C, 0x4D, 0x4E), tg::kGrey100);
++  mixer[kColorTabGroupBookmarkBarPink] =
++      ui::SelectBasedOnDarkInput(kColorBookmarkBarBackground,
++                                 SkColorSetRGB(0x55, 0x39, 0x49), tg::kPink050);
+   mixer[kColorTabGroupBookmarkBarPurple] = ui::SelectBasedOnDarkInput(
+       kColorBookmarkBarBackground, SkColorSetRGB(0x47, 0x39, 0x54),
+-      gfx::kGooglePurple050);
+-  mixer[kColorTabGroupBookmarkBarRed] = ui::SelectBasedOnDarkInput(
+-      kColorBookmarkBarBackground, SkColorSetRGB(0x52, 0x39, 0x37),
+-      gfx::kGoogleRed050);
++      tg::kPurple050);
++  mixer[kColorTabGroupBookmarkBarRed] =
++      ui::SelectBasedOnDarkInput(kColorBookmarkBarBackground,
++                                 SkColorSetRGB(0x52, 0x39, 0x37), tg::kRed050);
+   mixer[kColorTabGroupBookmarkBarYellow] = ui::SelectBasedOnDarkInput(
+       kColorBookmarkBarBackground, SkColorSetRGB(0x55, 0x4B, 0x30),
+-      gfx::kGoogleYellow050);
++      tg::kYellow050);
+   mixer[kColorTabGroupBookmarkBarOrange] = ui::SelectBasedOnDarkInput(
+       kColorBookmarkBarBackground, SkColorSetRGB(0x54, 0x42, 0x33),
+-      gfx::kGoogleOrange050);
++      tg::kOrange050);
+ 
+   mixer[kColorTabHoverCardBackground] = {dark_mode ? gfx::kGoogleGrey900
+                                                    : gfx::kGoogleGrey050};
+@@ -729,58 +740,58 @@ void AddChromeColorMixer(ui::ColorProvid
+   mixer[kColorThumbnailTabStripBackgroundInactive] = {ui::kColorFrameInactive};
+   mixer[kColorThumbnailTabStripTabGroupFrameActiveBlue] =
+       ui::SelectBasedOnDarkInput(kColorThumbnailTabStripBackgroundActive,
+-                                 gfx::kGoogleBlue300, gfx::kGoogleBlue600);
++                                 tg::kBlue300, tg::kBlue600);
+   mixer[kColorThumbnailTabStripTabGroupFrameActiveCyan] =
+       ui::SelectBasedOnDarkInput(kColorThumbnailTabStripBackgroundActive,
+-                                 gfx::kGoogleCyan300, gfx::kGoogleCyan900);
++                                 tg::kCyan300, tg::kCyan900);
+   mixer[kColorThumbnailTabStripTabGroupFrameActiveGreen] =
+       ui::SelectBasedOnDarkInput(kColorThumbnailTabStripBackgroundActive,
+-                                 gfx::kGoogleGreen300, gfx::kGoogleGreen700);
++                                 tg::kGreen300, tg::kGreen700);
+   mixer[kColorThumbnailTabStripTabGroupFrameActiveGrey] =
+       ui::SelectBasedOnDarkInput(kColorThumbnailTabStripBackgroundActive,
+-                                 gfx::kGoogleGrey300, gfx::kGoogleGrey700);
++                                 tg::kGrey300, tg::kGrey700);
+   mixer[kColorThumbnailTabStripTabGroupFrameActiveOrange] =
+       ui::SelectBasedOnDarkInput(kColorThumbnailTabStripBackgroundActive,
+-                                 gfx::kGoogleOrange300, gfx::kGoogleOrange400);
++                                 tg::kOrange300, tg::kOrange400);
+   mixer[kColorThumbnailTabStripTabGroupFrameActivePink] =
+       ui::SelectBasedOnDarkInput(kColorThumbnailTabStripBackgroundActive,
+-                                 gfx::kGooglePink300, gfx::kGooglePink700);
++                                 tg::kPink300, tg::kPink700);
+   mixer[kColorThumbnailTabStripTabGroupFrameActivePurple] =
+       ui::SelectBasedOnDarkInput(kColorThumbnailTabStripBackgroundActive,
+-                                 gfx::kGooglePurple300, gfx::kGooglePurple500);
++                                 tg::kPurple300, tg::kPurple500);
+   mixer[kColorThumbnailTabStripTabGroupFrameActiveRed] =
+       ui::SelectBasedOnDarkInput(kColorThumbnailTabStripBackgroundActive,
+-                                 gfx::kGoogleRed300, gfx::kGoogleRed600);
++                                 tg::kRed300, tg::kRed600);
+   mixer[kColorThumbnailTabStripTabGroupFrameActiveYellow] =
+       ui::SelectBasedOnDarkInput(kColorThumbnailTabStripBackgroundActive,
+-                                 gfx::kGoogleYellow300, gfx::kGoogleYellow600);
++                                 tg::kYellow300, tg::kYellow600);
+   mixer[kColorThumbnailTabStripTabGroupFrameInactiveBlue] =
+       ui::SelectBasedOnDarkInput(kColorThumbnailTabStripBackgroundInactive,
+-                                 gfx::kGoogleBlue300, gfx::kGoogleBlue600);
++                                 tg::kBlue300, tg::kBlue600);
+   mixer[kColorThumbnailTabStripTabGroupFrameInactiveCyan] =
+       ui::SelectBasedOnDarkInput(kColorThumbnailTabStripBackgroundInactive,
+-                                 gfx::kGoogleCyan300, gfx::kGoogleCyan900);
++                                 tg::kCyan300, tg::kCyan900);
+   mixer[kColorThumbnailTabStripTabGroupFrameInactiveGreen] =
+       ui::SelectBasedOnDarkInput(kColorThumbnailTabStripBackgroundInactive,
+-                                 gfx::kGoogleGreen300, gfx::kGoogleGreen700);
++                                 tg::kGreen300, tg::kGreen700);
+   mixer[kColorThumbnailTabStripTabGroupFrameInactiveGrey] =
+       ui::SelectBasedOnDarkInput(kColorThumbnailTabStripBackgroundInactive,
+-                                 gfx::kGoogleGrey300, gfx::kGoogleGrey700);
++                                 tg::kGrey300, tg::kGrey700);
+   mixer[kColorThumbnailTabStripTabGroupFrameInactiveOrange] =
+       ui::SelectBasedOnDarkInput(kColorThumbnailTabStripBackgroundInactive,
+-                                 gfx::kGoogleOrange300, gfx::kGoogleOrange400);
++                                 tg::kOrange300, tg::kOrange400);
+   mixer[kColorThumbnailTabStripTabGroupFrameInactivePink] =
+       ui::SelectBasedOnDarkInput(kColorThumbnailTabStripBackgroundInactive,
+-                                 gfx::kGooglePink300, gfx::kGooglePink700);
++                                 tg::kPink300, tg::kPink700);
+   mixer[kColorThumbnailTabStripTabGroupFrameInactivePurple] =
+       ui::SelectBasedOnDarkInput(kColorThumbnailTabStripBackgroundInactive,
+-                                 gfx::kGooglePurple300, gfx::kGooglePurple500);
++                                 tg::kPurple300, tg::kPurple500);
+   mixer[kColorThumbnailTabStripTabGroupFrameInactiveRed] =
+       ui::SelectBasedOnDarkInput(kColorThumbnailTabStripBackgroundInactive,
+-                                 gfx::kGoogleRed300, gfx::kGoogleRed600);
++                                 tg::kRed300, tg::kRed600);
+   mixer[kColorThumbnailTabStripTabGroupFrameInactiveYellow] =
+       ui::SelectBasedOnDarkInput(kColorThumbnailTabStripBackgroundInactive,
+-                                 gfx::kGoogleYellow300, gfx::kGoogleYellow600);
++                                 tg::kYellow300, tg::kYellow600);
+ 
+   mixer[kColorToolbar] = {dark_mode ? SkColorSetRGB(0x35, 0x36, 0x3A)
+                                     : SK_ColorWHITE};
+@@ -810,8 +821,10 @@ void AddChromeColorMixer(ui::ColorProvid
        ui::SetAlpha(kColorToolbarButtonIcon, gfx::kGoogleGreyAlpha500)};
    mixer[kColorToolbarButtonIconPressed] = {kColorToolbarButtonIconHovered};
    mixer[kColorToolbarButtonText] = ui::GetColorWithMaxContrast(kColorToolbar);
@@ -75,8 +474,10 @@
    mixer[kColorToolbarFeaturePromoHighlight] =
        ui::PickGoogleColor(ui::kColorAccent, kColorToolbar,
                            color_utils::kMinimumVisibleContrastRatio);
---- a/ui/color/ui_color_mixer.cc
-+++ b/ui/color/ui_color_mixer.cc
+Index: src/ui/color/ui_color_mixer.cc
+===================================================================
+--- src.orig/ui/color/ui_color_mixer.cc
++++ src/ui/color/ui_color_mixer.cc
 @@ -31,7 +31,8 @@ void AddUiColorMixer(ColorProvider* prov
    mixer[kColorBadgeInCocoaMenuBackground] = {kColorBadgeBackground};
    mixer[kColorBadgeInCocoaMenuForeground] = {kColorBadgeForeground};
@@ -87,8 +488,10 @@
    mixer[kColorBubbleBorderShadowLarge] = {SetAlpha(kColorShadowBase, 0x1A)};
    mixer[kColorBubbleBorderShadowSmall] = {SetAlpha(kColorShadowBase, 0x33)};
    mixer[kColorBubbleFooterBackground] = {kColorSubtleEmphasisBackground};
---- a/chrome/browser/ui/color/material_tab_strip_color_mixer.cc
-+++ b/chrome/browser/ui/color/material_tab_strip_color_mixer.cc
+Index: src/chrome/browser/ui/color/material_tab_strip_color_mixer.cc
+===================================================================
+--- src.orig/chrome/browser/ui/color/material_tab_strip_color_mixer.cc
++++ src/chrome/browser/ui/color/material_tab_strip_color_mixer.cc
 @@ -17,6 +17,10 @@ constexpr SkAlpha kWebUiTabStripScrollba
  
  /* 16% opacity */
@@ -183,8 +586,10 @@
  
    mixer[kColorTabSearchButtonCRForegroundFrameActive] = {
        ui::kColorSysOnSurfacePrimary};
---- a/ui/color/sys_color_mixer.cc
-+++ b/ui/color/sys_color_mixer.cc
+Index: src/ui/color/sys_color_mixer.cc
+===================================================================
+--- src.orig/ui/color/sys_color_mixer.cc
++++ src/ui/color/sys_color_mixer.cc
 @@ -66,7 +66,7 @@ void AddThemedSysColorOverrides(ColorMix
  
    // Experimentation.

--- a/patches/helium/ui/tabs.patch
+++ b/patches/helium/ui/tabs.patch
@@ -519,24 +519,7 @@
  
 --- a/chrome/browser/ui/views/tabs/tab_group_header.cc
 +++ b/chrome/browser/ui/views/tabs/tab_group_header.cc
-@@ -23,6 +23,7 @@
- #include "chrome/browser/ui/tabs/saved_tab_groups/saved_tab_group_utils.h"
- #include "chrome/browser/ui/tabs/tab_group_attention_indicator.h"
- #include "chrome/browser/ui/tabs/tab_group_features.h"
-+#include "chrome/browser/ui/tabs/tab_group_theme.h"
- #include "chrome/browser/ui/tabs/tab_style.h"
- #include "chrome/browser/ui/tabs/vertical_tab_strip_state_controller.h"
- #include "chrome/browser/ui/ui_features.h"
-@@ -81,6 +82,8 @@ namespace {
- // The amount of padding between the label and the sync icon.
- constexpr int kSyncIconPaddingFromLabel = 2;
- 
-+constexpr int kTabGroupStrokeThickness = 1;
-+
- bool SupportsDataSharing() {
-   return data_sharing::features::IsDataSharingFunctionalityEnabled();
- }
-@@ -514,7 +517,8 @@ std::u16string_view TabGroupHeader::GetT
+@@ -514,7 +514,8 @@ std::u16string_view TabGroupHeader::GetT
  
  int TabGroupHeader::GetDesiredWidth() const {
    const int overlap_margin = group_style_->GetTabGroupViewOverlap() * 2;
@@ -546,39 +529,6 @@
  }
  
  int TabGroupHeader::GetChipHeight() const {
-@@ -567,7 +571,11 @@ void TabGroupHeader::UpdateTitleView() {
-   title_->SetText(group_title_);
- 
-   if (!group_title_.empty()) {
--    title_->SetEnabledColor(color_utils::GetColorWithMaxContrast(color_));
-+    const SkColor text_color = GetColorProvider()->GetColor(
-+        GetSavedTabGroupForegroundColorId(
-+          tab_slot_controller_->GetGroupColorId(group().value())));
-+
-+    title_->SetEnabledColor(text_color);
-   }
- }
- 
-@@ -705,8 +713,18 @@ void TabGroupHeader::CreateHeaderWithTit
-   const int corner_radius = group_style_->GetChipCornerRadius();
-   title_chip_->SetBounds(named_origin.x(), chip_y, title_chip_width,
-                          chip_height);
-+  const tab_groups::TabGroupColorId group_color_id =
-+      tab_slot_controller_->GetGroupColorId(group().value());
-+
-+  const SkColor background_color =
-+      GetColorProvider()->GetColor(GetTabGroupBookmarkColorId(group_color_id));
-+  const SkColor stroke_color =
-+      GetColorProvider()->GetColor(GetSavedTabGroupOutlineColorId(group_color_id));
-+
-   title_chip_->SetBackground(
--      views::CreateRoundedRectBackground(color_, corner_radius));
-+      views::CreateRoundedRectBackground(background_color, corner_radius));
-+  title_chip_->SetBorder(views::CreateRoundedRectBorder(
-+      kTabGroupStrokeThickness, corner_radius, stroke_color));
- 
-   // Set the bounds of the sync icon first, followed by the title.
-   const int start_of_sync_icon = title_chip_insets.left();
 --- a/media/base/media_switches.cc
 +++ b/media/base/media_switches.cc
 @@ -379,7 +379,7 @@ BASE_FEATURE(kExtendedVideoBitstreamVali


### PR DESCRIPTION
For your pull request to not get closed without review, please confirm that:

- [ ] An issue exists where the maintainers agreed that this should be implemented
      (an approved feature request, or confirmed bug).
→ No, but the two open issues about this haven't been responded to in nearly 2 months
- [ ] I tested that my contribution works locally, and does not break anything,
      otherwise I have marked my PR as draft.
- [x] If my contribution is non-trivial, I did not use AI to write most of it.
- [x] I understand that I will be permanently banned from interacting with this
      organization if I lied by checking any of these checkboxes.

Tested on (check one or more):
- [ ] Windows
- [x] macOS
- [ ] Linux

---

https://github.com/user-attachments/assets/dc73e2d4-d6c8-4017-8780-fd5107ad053a


Adds better tab color group contrast. The labels are hard to read sometimes as demonstrated by https://github.com/imputnet/helium/issues/1536#issuecomment-4501984727.

Closes:
- https://github.com/imputnet/helium/issues/1536
- https://github.com/imputnet/helium/issues/1179
