### PR TITLE
helium/core/sync: name private vault structural limits precisely

### DIFF
--- a/patches/helium/core/sync/vault-format.patch
+++ b/patches/helium/core/sync/vault-format.patch
@@ -160,7 +160,7 @@
 +bool IsValidJournalRecord(const SyncVaultJournalRecord& record) {
 +  if (record.generation == 0 || record.creation_time_millis < 0 ||
 +      record.mutation_count == 0 || record.state_chunks.empty() ||
-+      record.state_chunks.size() > kSyncVaultMaximumEntities ||
++      record.state_chunks.size() > kSyncVaultMaximumStateChunks ||
 +      record.epoch >= record.generation) {
 +    return false;
 +  }
@@ -348,7 +348,7 @@
 +  }
 +  if (proto.state_chunks_size() <= 0 ||
 +      base::checked_cast<size_t>(proto.state_chunks_size()) >
-+          kSyncVaultMaximumEntities) {
++          kSyncVaultMaximumStateChunks) {
 +    return base::unexpected(SyncVaultFormatError::kInvalidValue);
 +  }
 +  SyncVaultJournalRecord record;
@@ -420,7 +420,7 @@
 +    base::span<const AuthenticatedSyncVaultJournalRecord>
 +        newest_first_ancestry) {
 +  if (!IsValidCheckpoint(checkpoint) || !IsValidHead(candidate_head) ||
-+      newest_first_ancestry.size() > kSyncVaultMaximumEntities) {
++      newest_first_ancestry.size() > kSyncVaultMaximumJournalAncestryRecords) {
 +    return SyncVaultHistoryValidationResult::kInvalidHistory;
 +  }
 +  if (candidate_head.generation < checkpoint.generation) {
@@ -474,7 +474,7 @@
 +}  // namespace syncer
 --- /dev/null
 +++ b/components/sync/engine/extension_sync/sync_vault_format.h
-@@ -0,0 +1,144 @@
+@@ -0,0 +1,145 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
@@ -495,7 +495,8 @@
 +
 +inline constexpr uint32_t kSyncVaultFormatVersion = 1;
 +inline constexpr size_t kSyncVaultMaximumReconstructedBytes = 256 * 1024 * 1024;
-+inline constexpr size_t kSyncVaultMaximumEntities = 100000;
++inline constexpr size_t kSyncVaultMaximumStateChunks = 100000;
++inline constexpr size_t kSyncVaultMaximumJournalAncestryRecords = 100000;
 +
 +enum class SyncVaultFormatError {
 +  kMalformed,

--- a/patches/helium/core/sync/vault-store.patch
+++ b/patches/helium/core/sync/vault-store.patch
@@ -11,7 +11,7 @@
  
 --- /dev/null
 +++ b/components/sync/engine/extension_sync/sync_vault_store.cc
-@@ -0,0 +1,895 @@
+@@ -0,0 +1,896 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
@@ -720,7 +720,8 @@
 +  }
 +
 +  if (checkpoint_.generation > 0 &&
-+      head.generation - checkpoint_.generation > kSyncVaultMaximumEntities) {
++      head.generation - checkpoint_.generation >
++          kSyncVaultMaximumJournalAncestryRecords) {
 +    return base::unexpected(SyncVaultStoreError::kObjectTooLarge);
 +  }
 +
@@ -743,7 +744,7 @@
 +      break;
 +    }
 +    if (record_generation <= checkpoint_.generation + 1 ||
-+        ancestry.size() >= kSyncVaultMaximumEntities) {
++        ancestry.size() >= kSyncVaultMaximumJournalAncestryRecords) {
 +      return base::unexpected(SyncVaultStoreError::kIncompleteHistory);
 +    }
 +


### PR DESCRIPTION
the MaximumEntities name suggested a limit on sync entities, but it actually bounded state chunk references and journal ancestry traversal.

give each use a distinct name so the limits cannot be mistaken for a cap on user data.

Related: #90
