### PR TITLE
helium/core/sync: use chromium ownership helpers in vault encryption

### DIFF
--- a/patches/helium/core/sync/vault-encryption.patch
+++ b/patches/helium/core/sync/vault-encryption.patch
@@ -37,6 +37,7 @@
 +#include <vector>
 +
 +#include "base/containers/span.h"
++#include "base/memory/ptr_util.h"
 +#include "base/notreached.h"
 +#include "base/strings/string_view_util.h"
 +#include "base/uuid.h"
@@ -79,18 +80,18 @@
 +  if (!parsed_uuid.is_valid() || vault_uuid.size() != 36u) {
 +    return base::unexpected(SyncVaultCryptoError::kInvalidContext);
 +  }
-+  return std::unique_ptr<SyncVaultCryptographer>(new SyncVaultCryptographer(
++  return base::WrapUnique(new SyncVaultCryptographer(
 +      vault_key.first<kVaultKeySize>(), parsed_uuid.AsLowercaseString()));
 +}
 +
 +SyncVaultCryptographer::SyncVaultCryptographer(
 +    base::span<const uint8_t, kVaultKeySize> vault_key,
 +    std::string vault_uuid)
-+    : object_key_(crypto::kdf::Hkdf<kVaultKeySize>(
-+          crypto::hash::kSha256,
-+          vault_key,
-+          base::as_byte_span(vault_uuid),
-+          base::as_byte_span(kKeyInfo))),
++    : object_key_(
++          crypto::kdf::Hkdf<kVaultKeySize>(crypto::hash::kSha256,
++                                           vault_key,
++                                           base::as_byte_span(vault_uuid),
++                                           base::as_byte_span(kKeyInfo))),
 +      vault_uuid_(std::move(vault_uuid)) {}
 +
 +SyncVaultCryptographer::~SyncVaultCryptographer() {
@@ -110,8 +111,7 @@
 +  std::array<uint8_t, kNonceBytes> nonce;
 +  crypto::RandBytes(nonce);
 +  std::vector<uint8_t> ciphertext = crypto::aead::Seal(
-+      kAlgorithm, object_key_, plaintext, nonce,
-+      BuildAssociatedData(role));
++      kAlgorithm, object_key_, plaintext, nonce, BuildAssociatedData(role));
 +  std::vector<uint8_t> container;
 +  container.reserve(nonce.size() + ciphertext.size());
 +  container.insert(container.end(), nonce.begin(), nonce.end());


### PR DESCRIPTION
this is a mechanical cleanup with no crypto/format changes

Related: #90