### PR TITLE
helium/ui: show tabs from non-account sync backends

### DIFF
--- a/patches/helium/ui/show-tabs-from-non-account-backends.patch
+++ b/patches/helium/ui/show-tabs-from-non-account-backends.patch
@@ -1,0 +1,89 @@
+--- a/chrome/browser/resources/history/app.html.ts
++++ b/chrome/browser/resources/history/app.html.ts
+@@ -140,14 +140,15 @@ export function getHtml(this: HistoryApp
+             </cr-page-selector>
+           </div>
+         </div>
+-        ${this.syncedTabsSelected_() ? html`
+           <div id="syncedDevicesScroll" class="cr-scrollable" path="syncedTabs">
+             <div class="cr-scrollable-top-shadow"></div>
++            ${this.syncedTabsSelected_() ? html`
+             <history-synced-device-manager id="synced-devices"
+                 .sessionList="${this.sessionList_}"
+                 .searchTerm="${this.queryState_.searchTerm}">
+             </history-synced-device-manager>
+-          </div>` : ''}
++            ` : ''}
++          </div>
+       </cr-page-selector>
+     </div>
+ 
+--- a/chrome/browser/resources/history/app.ts
++++ b/chrome/browser/resources/history/app.ts
+@@ -757,7 +757,6 @@ export class HistoryAppElement extends H
+         break;
+       case Page.SYNCED_TABS:
+         histogramValue =
+-            this.identityState_.signIn === HistorySignInState.SIGNED_IN &&
+                 this.identityState_.tabsSync === SyncState.TURNED_ON ?
+             HistoryPageViewHistogram.SYNCED_TABS :
+             HistoryPageViewHistogram.SIGNIN_PROMO;
+@@ -805,8 +804,7 @@ export class HistoryAppElement extends H
+   protected shouldShowHistoryPageHistorySyncPromo_(): boolean {
+     return this.unoPhase2FollowUpEnabled_ && this.shouldShowHistorySyncPromo_ &&
+         this.identityState_.historySync !== SyncState.DISABLED &&
+-        !(this.identityState_.signIn === HistorySignInState.SIGNED_IN &&
+-          this.identityState_.historySync === SyncState.TURNED_ON);
++        this.identityState_.historySync !== SyncState.TURNED_ON;
+   }
+ 
+   private handleShouldShowHistoryPageHistorySyncPromoChanged_(
+--- a/chrome/browser/resources/history/synced_device_manager.ts
++++ b/chrome/browser/resources/history/synced_device_manager.ts
+@@ -335,8 +335,7 @@ export class HistorySyncedDeviceManagerE
+   protected shouldShowHistorySyncOptIn_(): boolean {
+     return this.replaceSyncPromosWithSignInPromos_ &&
+         !this.isTabsSyncDisabled_() &&
+-        !(this.isSignInState_(HistorySignInState.SIGNED_IN) &&
+-          this.isTabsSyncTurnedOn_());
++        !this.isTabsSyncTurnedOn_();
+   }
+ 
+   protected isTabsSyncTurnedOn_(): boolean {
+@@ -355,8 +354,7 @@ export class HistorySyncedDeviceManagerE
+       return true;
+     }
+ 
+-    return this.isSignInState_(HistorySignInState.SIGNED_IN) &&
+-        this.isTabsSyncTurnedOn_() && this.syncedDevices_.length === 0;
++    return this.isTabsSyncTurnedOn_() && this.syncedDevices_.length === 0;
+   }
+ 
+   /**
+@@ -365,7 +363,8 @@ export class HistorySyncedDeviceManagerE
+    */
+   protected showSignInGuide_(): boolean {
+     const show = this.isSignInState_(HistorySignInState.SIGNED_OUT) &&
+-        !this.guestSession_ && this.signInAllowed_;
++        !this.isTabsSyncTurnedOn_() && !this.guestSession_ &&
++        this.signInAllowed_;
+     if (show) {
+       BrowserProxyImpl.getInstance().recordAction(
+           'Signin_Impression_FromRecentTabs');
+@@ -435,10 +434,12 @@ export class HistorySyncedDeviceManagerE
+     this.fire('history-view-changed');
+ 
+     if (this.replaceSyncPromosWithSignInPromos_) {
+-      // User signed out, syncing without tabs, or disabled sync in general =>
+-      // clear synced device list.
+-      if (this.isSignInState_(HistorySignInState.SIGNED_OUT) ||
+-          this.isTabsSyncDisabled_()) {
++      // A non-account backend can sync tabs without a signed-in identity.
++      // Clear foreign sessions only when tabs cannot be synced in the current
++      // context.
++      if (this.isTabsSyncDisabled_() ||
++          (this.isSignInState_(HistorySignInState.SIGNED_OUT) &&
++           !this.isTabsSyncTurnedOn_())) {
+         this.clearDisplayedSyncedDevices_();
+         this.sessionList = null;
+         return;

--- a/patches/series
+++ b/patches/series
@@ -346,3 +346,4 @@ helium/ui/native-frame-materials.patch
 helium/ui/page-zoom-indicator.patch
 helium/ui/add-more-zoom-presets.patch
 helium/ui/helium-noise-page-info.patch
+helium/ui/show-tabs-from-non-account-backends.patch


### PR DESCRIPTION
chromium's history UI assumes that synced sessions require a signed-in account. derive history and tab availability from sync state rather than identity

Related: #90