### PR TITLE
helium/core/sync/provider: define extension api contract

### DIFF
--- a/i18n/source.gen.json
+++ b/i18n/source.gen.json
@@ -186,6 +186,12 @@
     "message": "This list of search engines is shown in random order."
   },
   {
+    "name": "IDS_EXTENSION_PROMPT_WARNING_SYNC_VAULT_PROVIDER",
+    "source": "chrome/app/generated_resources.grd",
+    "context": "Permission string for extensions that store encrypted browser synchronization data.",
+    "message": "Act as a storage provider for your encrypted browser synchronization data"
+  },
+  {
     "name": "IDS_SETTINGS_APPEARANCE_AND_BEHAVIOR",
     "source": "chrome/app/settings_strings.grdp",
     "context": "Name of the settings page which displays appearance and behavior preferences.",

--- a/patches/helium/core/close-tabs-to-left.patch
+++ b/patches/helium/core/close-tabs-to-left.patch
@@ -1,6 +1,6 @@
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -12011,6 +12011,9 @@ Check your passwords anytime in <ph name
+@@ -12014,6 +12014,9 @@ Check your passwords anytime in <ph name
          <message name="IDS_TAB_CXMENU_CLOSETABSBELOW" desc="The label of the 'Close Tabs Below' Tab context menu item.">
            Close tabs below
          </message>
@@ -10,7 +10,7 @@
          <message name="IDS_TAB_CXMENU_CLOSEALLTABS" desc="The label of the 'Close All Tabs' Tab context menu item.">
            Close all tabs
          </message>
-@@ -12133,6 +12136,9 @@ Check your passwords anytime in <ph name
+@@ -12136,6 +12139,9 @@ Check your passwords anytime in <ph name
          <message name="IDS_TAB_CXMENU_CLOSETABSBELOW" desc="In Title Case: The label of the 'Close Tabs Below' Tab context menu item.">
            Close Tabs Below
          </message>

--- a/patches/helium/core/component-updates.patch
+++ b/patches/helium/core/component-updates.patch
@@ -161,7 +161,7 @@
             std::move(callback), cus->GetRegisteredVersion(crx_id),
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -6905,6 +6905,9 @@ Keep your key file in a safe place. You
+@@ -6908,6 +6908,9 @@ Keep your key file in a safe place. You
        <message name="IDS_COMPONENTS_SVC_STATUS_UPDATE_ERROR" desc="Service Status">
          Update error
        </message>

--- a/patches/helium/core/copy-url-tab-context-menu.patch
+++ b/patches/helium/core/copy-url-tab-context-menu.patch
@@ -1,6 +1,6 @@
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -12104,6 +12104,12 @@ Check your passwords anytime in <ph name
+@@ -12107,6 +12107,12 @@ Check your passwords anytime in <ph name
          <message name="IDS_TAB_CXMENU_HIBERNATE_OTHER_TABS" desc="The label of the 'Hibernate other tabs' Tab context menu item.">
            Hibernate other tabs
          </message>
@@ -13,7 +13,7 @@
          <message name="IDS_TAB_CXMENU_CLOSETAB" desc="The label of the tab context menu item for closing one or more tabs.">
            Close
          </message>
-@@ -12229,6 +12235,12 @@ Check your passwords anytime in <ph name
+@@ -12232,6 +12238,12 @@ Check your passwords anytime in <ph name
          <message name="IDS_TAB_CXMENU_HIBERNATE_OTHER_TABS" desc="In Title Case: The label of the 'Hibernate Other Tabs' Tab context menu item.">
            Hibernate Other Tabs
          </message>

--- a/patches/helium/core/hibernate-tab-context-menu.patch
+++ b/patches/helium/core/hibernate-tab-context-menu.patch
@@ -1,6 +1,6 @@
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -11990,6 +11990,12 @@ Check your passwords anytime in <ph name
+@@ -11993,6 +11993,12 @@ Check your passwords anytime in <ph name
          <message name="IDS_TAB_CXMENU_DUPLICATE" desc="The label of the 'Duplicate' Tab context menu item.">
            Duplicate
          </message>
@@ -13,7 +13,7 @@
          <message name="IDS_TAB_CXMENU_CLOSETAB" desc="The label of the tab context menu item for closing one or more tabs.">
            Close
          </message>
-@@ -12106,6 +12112,12 @@ Check your passwords anytime in <ph name
+@@ -12109,6 +12115,12 @@ Check your passwords anytime in <ph name
          <message name="IDS_TAB_CXMENU_DUPLICATE" desc="In Title Case: The label of the 'Duplicate' Tab context menu item.">
            Duplicate
          </message>

--- a/patches/helium/core/sync/provider/api-contract.patch
+++ b/patches/helium/core/sync/provider/api-contract.patch
@@ -1,0 +1,435 @@
+--- a/extensions/common/extension_features.cc
++++ b/extensions/common/extension_features.cc
+@@ -84,6 +84,8 @@ BASE_FEATURE(kApiProxyOverrideRulesPriva
+ BASE_FEATURE(kApiRuntimeGetPlatformInfoNaClArch,
+              base::FEATURE_ENABLED_BY_DEFAULT);
+ 
++BASE_FEATURE(kApiSyncVaultProvider, base::FEATURE_DISABLED_BY_DEFAULT);
++
+ BASE_FEATURE(kWebRequestSecurityInfo, base::FEATURE_DISABLED_BY_DEFAULT);
+ 
+ BASE_FEATURE(kWebRequestPerContextEventDispatch,
+--- a/extensions/common/extension_features.h
++++ b/extensions/common/extension_features.h
+@@ -112,6 +112,9 @@ BASE_DECLARE_FEATURE(kApiProxyOverrideRu
+ // runtime.getPlatformInfo() API.
+ BASE_DECLARE_FEATURE(kApiRuntimeGetPlatformInfoNaClArch);
+ 
++// Controls the availability of the experimental syncVaultProvider API.
++BASE_DECLARE_FEATURE(kApiSyncVaultProvider);
++
+ ///////////////////////////////////////////////////////////////////////////////
+ // Other Features
+ ///////////////////////////////////////////////////////////////////////////////
+--- a/extensions/common/features/feature_flags.cc
++++ b/extensions/common/features/feature_flags.cc
+@@ -27,6 +27,7 @@ const base::Feature* kFeatureFlags[] = {
+     &extensions_features::kApiGlicAccessFromGoogleWebpage,
+     &extensions_features::kApiMimeHandler,
+     &extensions_features::kApiPermissionsHostAccessRequests,
++    &extensions_features::kApiSyncVaultProvider,
+     &extensions_features::kApiUserScriptsExecute,
+     &extensions_features::kApiUserScriptsMultipleWorlds,
+     &extensions_features::kApiGlicPrivate,
+--- a/extensions/common/mojom/api_permission_id.mojom
++++ b/extensions/common/mojom/api_permission_id.mojom
+@@ -294,6 +294,7 @@ enum APIPermissionID {
+   kIndigoPrivate = 267,
+   kContextualTasksPrivate = 268,
+   kDictationPrivate = 269,
++  kSyncVaultProvider = 270,
+ 
+   // Add new entries at the end of the enum and be sure to update the
+   // "ExtensionPermission3" enum in
+--- a/chrome/common/extensions/api/_api_features.json
++++ b/chrome/common/extensions/api/_api_features.json
+@@ -1102,6 +1102,11 @@
+       "chrome://file-manager/*"
+     ]
+   }],
++  "syncVaultProvider": {
++    "dependencies": ["permission:syncVaultProvider"],
++    "contexts": ["privileged_extension"],
++    "feature_flag": "ApiSyncVaultProvider"
++  },
+   "webAuthenticationProxy": {
+     "dependencies": ["permission:webAuthenticationProxy"],
+     "contexts": ["privileged_extension"]
+--- a/chrome/common/extensions/api/_permission_features.json
++++ b/chrome/common/extensions/api/_permission_features.json
+@@ -1171,6 +1171,13 @@
+       "81986D4F846CEDDDB962643FA501D1780DD441BB"   // http://crbug.com/40546373
+     ]
+   },
++  "syncVaultProvider": {
++    "channel": "stable",
++    "extension_types": ["extension"],
++    "min_manifest_version": 3,
++    "platforms": ["linux", "mac", "win"],
++    "feature_flag": "ApiSyncVaultProvider"
++  },
+   "wmDesksPrivate": {
+     "channel": "stable",
+     "extension_types": ["extension", "platform_app"],
+--- a/chrome/common/extensions/api/api_sources.gni
++++ b/chrome/common/extensions/api/api_sources.gni
+@@ -102,7 +102,10 @@ if (enable_extensions) {
+   ]
+ 
+   if (is_win || is_mac || is_linux) {
+-    schema_sources_ += [ "web_authentication_proxy.webidl" ]
++    schema_sources_ += [
++      "sync_vault_provider.webidl",
++      "web_authentication_proxy.webidl",
++    ]
+   }
+ 
+   if (is_win || is_mac || is_linux || is_chromeos) {
+--- a/chrome/app/generated_resources.grd
++++ b/chrome/app/generated_resources.grd
+@@ -5557,6 +5557,9 @@ are declared in tools/grit/grit_args.gni
+         <message name="IDS_EXTENSION_PROMPT_WARNING_VPN" desc="Permission string for access to VPN API.">
+           Access your network traffic
+         </message>
++        <message name="IDS_EXTENSION_PROMPT_WARNING_SYNC_VAULT_PROVIDER" desc="Permission string for extensions that store encrypted browser synchronization data.">
++          Act as a storage provider for your encrypted browser synchronization data
++        </message>
+ 
+         <message name="IDS_EXTENSION_PROMPT_WARNING_CONTENT_SETTINGS" desc="Permission string for access to content settings.">
+           Change and grant access to features such as geolocation, microphone, camera, cookies, etc., for all your websites and extensions, including this extension.
+--- /dev/null
++++ b/chrome/common/extensions/api/sync_vault_provider.webidl
+@@ -0,0 +1,241 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++enum SyncVaultProviderError {
++  "AUTH_REQUIRED",
++  "NOT_FOUND",
++  "CONFLICT",
++  "NETWORK_ERROR",
++  "TEMPORARY_ERROR",
++  "QUOTA_EXCEEDED",
++  "ACCESS_DENIED",
++  "INVALID_DATA",
++  "UNSUPPORTED",
++  "ABORTED"
++};
++
++enum ProviderState {
++  "READY",
++  "AUTH_REQUIRED",
++  "OFFLINE",
++  "QUOTA_EXCEEDED"
++};
++
++enum ProviderConfigurationState {
++  // Provider-owned work is continuing without user input.
++  "CONFIGURING",
++  // The provider has presented UI and is waiting for the user.
++  "PENDING_USER_ACTION",
++  // Terminal success.
++  "READY"
++};
++
++dictionary ProviderRequest {
++  required long requestId;
++};
++
++// Creation is idempotent by vaultUuid. Retrying the same UUID must return
++// success for the same logical vault rather than creating another vault.
++dictionary CreateVaultRequest {
++  required long requestId;
++  // Browser-generated stable identity. Providers store and return this value
++  // but must not treat it as authenticated.
++  required DOMString vaultUuid;
++  // Provider-visible discovery label. It is not part of vault identity or the
++  // authenticated vault format.
++  required DOMString displayName;
++};
++
++dictionary RenameVaultRequest {
++  required long requestId;
++  required DOMString vaultUuid;
++  required DOMString displayName;
++};
++
++dictionary ReadObjectRequest {
++  required long requestId;
++  required DOMString vaultUuid;
++  required DOMString objectId;
++  required long maxBytes;
++};
++
++dictionary WriteObjectRequest {
++  required long requestId;
++  required DOMString vaultUuid;
++  required DOMString objectId;
++  required ArrayBuffer data;
++  // Missing means create only if absent. Present means replace only if the
++  // provider's current revision matches this value.
++  DOMString expectedRevision;
++  // Present for immutable commit and payload objects. Providers record this
++  // value as object metadata so epoch collection never depends on parsing the
++  // browser-owned object identifier.
++  long retentionEpoch;
++};
++
++dictionary CollectEpochsRequest {
++  required long requestId;
++  required DOMString vaultUuid;
++  // Delete provider objects belonging to epochs below this value. The
++  // operation is idempotent and must not affect fixed vault metadata.
++  required long minimumRetainedEpoch;
++};
++
++dictionary WrapKeyRequest {
++  required long requestId;
++  required DOMString vaultUuid;
++  // Browser-generated 32-byte vault master key. Sent only after the user
++  // consents to account-bound key access. The provider wraps this key using
++  // its account credentials and returns |ProviderSuccess.keyEnvelope|.
++  required ArrayBuffer vaultKey;
++};
++
++dictionary UnwrapKeyRequest {
++  required long requestId;
++  required DOMString vaultUuid;
++  // Opaque provider-defined value returned by an earlier wrap request.
++  // The provider unwraps it for the current account and returns the
++  // original key as |ProviderSuccess.vaultKey|.
++  required ArrayBuffer keyEnvelope;
++};
++
++dictionary VaultInfo {
++  // Provider-visible discovery label. The browser treats this as display-only
++  // metadata and permits duplicate names.
++  required DOMString displayName;
++  // Untrusted copy of the browser-generated vault identity. The browser still
++  // authenticates the encrypted head before joining the vault.
++  required DOMString vaultUuid;
++};
++
++dictionary ProviderSuccess {
++  // CONFIGURING and PENDING_USER_ACTION keep a configuration request active
++  // and may be reported repeatedly as progress changes. A later success
++  // response with READY completes that same request.
++  ProviderConfigurationState configurationState;
++  sequence<VaultInfo> vaults;
++  ArrayBuffer data;
++  DOMString revision;
++  // Opaque account-bound wrapping of the vault key.
++  // Valid only when responding to onWrapKeyRequested.
++  ArrayBuffer keyEnvelope;
++  // Original 32-byte vault master key recovered from a key envelope.
++  // Valid only when responding to onUnwrapKeyRequested.
++  ArrayBuffer vaultKey;
++};
++
++dictionary ProviderFailure {
++  required SyncVaultProviderError error;
++  DOMString message;
++};
++
++// Exactly one of success and failure must be present. The broker also validates
++// the exact success fields permitted for the pending operation.
++dictionary ProviderResponse {
++  required long requestId;
++  ProviderSuccess success;
++  ProviderFailure failure;
++};
++
++dictionary RequestCancellation {
++  // For an asynchronous configure request, this cancels the entire lifecycle,
++  // including work continued after CONFIGURING or PENDING_USER_ACTION.
++  required long requestId;
++};
++
++// A transport hint, not authoritative state. Providers report only that a
++// vault may have changed; the browser reads and authenticates its current head.
++dictionary VaultChange {
++  required DOMString vaultUuid;
++};
++
++dictionary ProviderStateChange {
++  required ProviderState state;
++};
++
++callback ProviderRequestListener = undefined (ProviderRequest request);
++callback CreateVaultRequestListener = undefined (CreateVaultRequest request);
++callback RenameVaultRequestListener = undefined (RenameVaultRequest request);
++callback ReadObjectRequestListener = undefined (ReadObjectRequest request);
++callback WriteObjectRequestListener = undefined (WriteObjectRequest request);
++callback CollectEpochsRequestListener = undefined (CollectEpochsRequest request);
++callback WrapKeyRequestListener = undefined (WrapKeyRequest request);
++callback UnwrapKeyRequestListener = undefined (UnwrapKeyRequest request);
++callback CancelRequestListener = undefined (RequestCancellation cancellation);
++
++interface ProviderRequestEvent : ExtensionEvent {
++  static undefined addListener(ProviderRequestListener listener);
++  static undefined removeListener(ProviderRequestListener listener);
++  static boolean hasListener(ProviderRequestListener listener);
++};
++
++interface CreateVaultRequestEvent : ExtensionEvent {
++  static undefined addListener(CreateVaultRequestListener listener);
++  static undefined removeListener(CreateVaultRequestListener listener);
++  static boolean hasListener(CreateVaultRequestListener listener);
++};
++
++interface RenameVaultRequestEvent : ExtensionEvent {
++  static undefined addListener(RenameVaultRequestListener listener);
++  static undefined removeListener(RenameVaultRequestListener listener);
++  static boolean hasListener(RenameVaultRequestListener listener);
++};
++
++interface ReadObjectRequestEvent : ExtensionEvent {
++  static undefined addListener(ReadObjectRequestListener listener);
++  static undefined removeListener(ReadObjectRequestListener listener);
++  static boolean hasListener(ReadObjectRequestListener listener);
++};
++
++interface WriteObjectRequestEvent : ExtensionEvent {
++  static undefined addListener(WriteObjectRequestListener listener);
++  static undefined removeListener(WriteObjectRequestListener listener);
++  static boolean hasListener(WriteObjectRequestListener listener);
++};
++
++interface CollectEpochsRequestEvent : ExtensionEvent {
++  static undefined addListener(CollectEpochsRequestListener listener);
++  static undefined removeListener(CollectEpochsRequestListener listener);
++  static boolean hasListener(CollectEpochsRequestListener listener);
++};
++
++interface WrapKeyRequestEvent : ExtensionEvent {
++  static undefined addListener(WrapKeyRequestListener listener);
++  static undefined removeListener(WrapKeyRequestListener listener);
++  static boolean hasListener(WrapKeyRequestListener listener);
++};
++
++interface UnwrapKeyRequestEvent : ExtensionEvent {
++  static undefined addListener(UnwrapKeyRequestListener listener);
++  static undefined removeListener(UnwrapKeyRequestListener listener);
++  static boolean hasListener(UnwrapKeyRequestListener listener);
++};
++
++interface CancelRequestEvent : ExtensionEvent {
++  static undefined addListener(CancelRequestListener listener);
++  static undefined removeListener(CancelRequestListener listener);
++  static boolean hasListener(CancelRequestListener listener);
++};
++
++interface SyncVaultProvider {
++  static Promise<undefined> respond(ProviderResponse response);
++  static Promise<undefined> notifyVaultChanged(VaultChange change);
++  static Promise<undefined> notifyProviderStateChanged(
++      ProviderStateChange change);
++
++  static attribute ProviderRequestEvent onConfigureRequested;
++  static attribute ProviderRequestEvent onListVaultsRequested;
++  static attribute CreateVaultRequestEvent onCreateVaultRequested;
++  static attribute RenameVaultRequestEvent onRenameVaultRequested;
++  static attribute ReadObjectRequestEvent onReadObjectRequested;
++  static attribute WriteObjectRequestEvent onWriteObjectRequested;
++  static attribute CollectEpochsRequestEvent onCollectEpochsRequested;
++  static attribute WrapKeyRequestEvent onWrapKeyRequested;
++  static attribute UnwrapKeyRequestEvent onUnwrapKeyRequested;
++  static attribute CancelRequestEvent onCancelRequested;
++};
++
++partial interface Browser {
++  static attribute SyncVaultProvider syncVaultProvider;
++};
+--- a/chrome/common/extensions/permissions/chrome_api_permissions.cc
++++ b/chrome/common/extensions/permissions/chrome_api_permissions.cc
+@@ -54,6 +54,9 @@ constexpr APIPermissionInfo::InitInfo pe
+     {APIPermissionID::kIdentityEmail, "identity.email"},
+     {APIPermissionID::kNotifications, "notifications",
+      APIPermissionInfo::kFlagDoesNotRequireManagedSessionFullLoginWarning},
++    {APIPermissionID::kSyncVaultProvider, "syncVaultProvider",
++     APIPermissionInfo::kFlagCannotBeOptional |
++         APIPermissionInfo::kFlagRequiresManagementUIWarning},
+ 
+     // Register extension permissions.
+     {APIPermissionID::kAccessibilityFeaturesModify,
+--- a/chrome/common/extensions/permissions/chrome_permission_message_rules.cc
++++ b/chrome/common/extensions/permissions/chrome_permission_message_rules.cc
+@@ -674,6 +674,9 @@ ChromePermissionMessageRule::GetAllRules
+       {IDS_EXTENSION_PROMPT_WARNING_SYNCFILESYSTEM,
+        {APIPermissionID::kSyncFileSystem},
+        {}},
++      {IDS_EXTENSION_PROMPT_WARNING_SYNC_VAULT_PROVIDER,
++       {APIPermissionID::kSyncVaultProvider},
++       {}},
+       {IDS_EXTENSION_PROMPT_WARNING_TAB_GROUPS,
+        {APIPermissionID::kTabGroups},
+        {}},
+--- a/tools/metrics/histograms/metadata/extensions/enums.xml
++++ b/tools/metrics/histograms/metadata/extensions/enums.xml
+@@ -818,6 +818,16 @@ Called by update_extension_histograms.py
+   <int value="575" label="DICTATION_PRIVATE_ON_START_STREAM"/>
+   <int value="576" label="DICTATION_PRIVATE_ON_END_STREAM"/>
+   <int value="577" label="DICTATION_PRIVATE_ON_CONTEXT_UPDATE"/>
++  <int value="578" label="SYNC_VAULT_PROVIDER_ON_CONFIGURE_REQUESTED"/>
++  <int value="579" label="SYNC_VAULT_PROVIDER_ON_LIST_VAULTS_REQUESTED"/>
++  <int value="580" label="SYNC_VAULT_PROVIDER_ON_CREATE_VAULT_REQUESTED"/>
++  <int value="581" label="SYNC_VAULT_PROVIDER_ON_RENAME_VAULT_REQUESTED"/>
++  <int value="582" label="SYNC_VAULT_PROVIDER_ON_READ_OBJECT_REQUESTED"/>
++  <int value="583" label="SYNC_VAULT_PROVIDER_ON_WRITE_OBJECT_REQUESTED"/>
++  <int value="584" label="SYNC_VAULT_PROVIDER_ON_WRAP_KEY_REQUESTED"/>
++  <int value="585" label="SYNC_VAULT_PROVIDER_ON_UNWRAP_KEY_REQUESTED"/>
++  <int value="586" label="SYNC_VAULT_PROVIDER_ON_CANCEL_REQUESTED"/>
++  <int value="587" label="SYNC_VAULT_PROVIDER_ON_COLLECT_EPOCHS_REQUESTED"/>
+ </enum>
+ 
+ <!-- LINT.ThenChange(//extensions/browser/extension_event_histogram_value.h:HistogramValue) -->
+@@ -2917,6 +2927,9 @@ Called by update_extension_histograms.py
+   <int value="1975" label="CONTEXTUALTASKSPRIVATE_LAUNCHPANELINNEWTAB"/>
+   <int value="1976" label="DICTATIONPRIVATE_UPDATETRANSCRIPTION"/>
+   <int value="1977" label="DICTATIONPRIVATE_SETSTREAMSTATE"/>
++  <int value="1978" label="SYNCVAULTPROVIDER_RESPOND"/>
++  <int value="1979" label="SYNCVAULTPROVIDER_NOTIFYVAULTCHANGED"/>
++  <int value="1980" label="SYNCVAULTPROVIDER_NOTIFYPROVIDERSTATECHANGED"/>
+ </enum>
+ 
+ <!-- LINT.ThenChange(//extensions/browser/extension_function_histogram_value.h:HistogramValue) -->
+@@ -3307,6 +3320,7 @@ Called by update_extension_permission.py
+   <int value="267" label="kIndigoPrivate"/>
+   <int value="268" label="kContextualTasksPrivate"/>
+   <int value="269" label="kDictationPrivate"/>
++  <int value="270" label="kSyncVaultProvider"/>
+ </enum>
+ 
+ <enum name="ExtensionPolicyReinstallReason">
+--- a/extensions/browser/extension_event_histogram_value.h
++++ b/extensions/browser/extension_event_histogram_value.h
+@@ -599,6 +599,16 @@ enum HistogramValue {
+   DICTATION_PRIVATE_ON_START_STREAM = 575,
+   DICTATION_PRIVATE_ON_END_STREAM = 576,
+   DICTATION_PRIVATE_ON_CONTEXT_UPDATE = 577,
++  SYNC_VAULT_PROVIDER_ON_CONFIGURE_REQUESTED = 578,
++  SYNC_VAULT_PROVIDER_ON_LIST_VAULTS_REQUESTED = 579,
++  SYNC_VAULT_PROVIDER_ON_CREATE_VAULT_REQUESTED = 580,
++  SYNC_VAULT_PROVIDER_ON_RENAME_VAULT_REQUESTED = 581,
++  SYNC_VAULT_PROVIDER_ON_READ_OBJECT_REQUESTED = 582,
++  SYNC_VAULT_PROVIDER_ON_WRITE_OBJECT_REQUESTED = 583,
++  SYNC_VAULT_PROVIDER_ON_WRAP_KEY_REQUESTED = 584,
++  SYNC_VAULT_PROVIDER_ON_UNWRAP_KEY_REQUESTED = 585,
++  SYNC_VAULT_PROVIDER_ON_CANCEL_REQUESTED = 586,
++  SYNC_VAULT_PROVIDER_ON_COLLECT_EPOCHS_REQUESTED = 587,
+   // Last entry: Add new entries above, then run:
+   // tools/metrics/histograms/update_extension_histograms.py
+   ENUM_BOUNDARY
+--- a/extensions/browser/extension_function_histogram_value.h
++++ b/extensions/browser/extension_function_histogram_value.h
+@@ -2040,6 +2040,9 @@ enum HistogramValue {
+   CONTEXTUALTASKSPRIVATE_LAUNCHPANELINNEWTAB = 1975,
+   DICTATIONPRIVATE_UPDATETRANSCRIPTION = 1976,
+   DICTATIONPRIVATE_SETSTREAMSTATE = 1977,
++  SYNCVAULTPROVIDER_RESPOND = 1978,
++  SYNCVAULTPROVIDER_NOTIFYVAULTCHANGED = 1979,
++  SYNCVAULTPROVIDER_NOTIFYPROVIDERSTATECHANGED = 1980,
+   // Last entry: Add new entries above, then run:
+   // tools/metrics/histograms/update_extension_histograms.py
+   ENUM_BOUNDARY

--- a/patches/helium/core/sync/vault-transport.patch
+++ b/patches/helium/core/sync/vault-transport.patch
@@ -1,6 +1,6 @@
 --- /dev/null
 +++ b/components/sync/engine/extension_sync/sync_vault_transport.h
-@@ -0,0 +1,72 @@
+@@ -0,0 +1,73 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
@@ -38,8 +38,9 @@
 +};
 +
 +// Transport-neutral access to one provider vault. Every payload is already an
-+// opaque authenticated ciphertext. Implementations must preserve exact
-+// revisions and report failed conditional writes as kConflict.
++// opaque authenticated ciphertext. Implementations must provide read-after-
++// write consistency, preserve stable exact revisions, atomically enforce
++// conditional writes, and report failed conditions as kConflict.
 +class SyncVaultTransport {
 + public:
 +  using ReadResult = base::expected<std::optional<OpaqueSyncVaultObject>,

--- a/patches/helium/ui/layout/context-menu.patch
+++ b/patches/helium/ui/layout/context-menu.patch
@@ -24,7 +24,7 @@
  #define IDC_ADD_NEW_TAB_TO_GROUP      34100
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -10462,6 +10462,51 @@ Keep your key file in a safe place. You
+@@ -10465,6 +10465,51 @@ Keep your key file in a safe place. You
                 Bottom
        </message>
  

--- a/patches/helium/ui/layout/zen-mode-wiring.patch
+++ b/patches/helium/ui/layout/zen-mode-wiring.patch
@@ -238,7 +238,7 @@
      {IDC_SHOW_BOOKMARK_MANAGER, ui::EF_COMMAND_DOWN | ui::EF_ALT_DOWN,
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -19353,6 +19353,9 @@ Please help our engineers fix this probl
+@@ -19356,6 +19356,9 @@ Please help our engineers fix this probl
        <message name="IDS_LINK_COPIED_TOAST_BODY" desc="Text on a toast notification that is shown when a link is successfully copied.">
          Link copied
        </message>

--- a/patches/helium/ui/side-panel-webui-customize.patch
+++ b/patches/helium/ui/side-panel-webui-customize.patch
@@ -1,6 +1,6 @@
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -7929,6 +7929,9 @@ Keep your key file in a safe place. You
+@@ -7932,6 +7932,9 @@ Keep your key file in a safe place. You
        <message name="IDS_NTP_CUSTOMIZE_CHROME_CHANGE_THEME_LABEL" desc="The label for the action button for changing Chrome theme in the New Tab Page customize chrome side panel.">
          Change theme
        </message>

--- a/patches/helium/ui/toolbar-button-prefs.patch
+++ b/patches/helium/ui/toolbar-button-prefs.patch
@@ -569,7 +569,7 @@
    // The container (and extensions-menu button) should not be visible if we have
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -10964,6 +10964,9 @@ Keep your key file in a safe place. You
+@@ -10967,6 +10967,9 @@ Keep your key file in a safe place. You
        <message name="IDS_ACCNAME_FIND" desc="The accessible name for the find button.">
          Find
        </message>

--- a/patches/helium/ui/ublock-show-in-settings.patch
+++ b/patches/helium/ui/ublock-show-in-settings.patch
@@ -87,7 +87,7 @@
  };
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -13867,6 +13867,9 @@ Check your passwords anytime in <ph name
+@@ -13870,6 +13870,9 @@ Check your passwords anytime in <ph name
          <message name="IDS_EXTENSIONS_INSTALL_LOCATION_SHARED_MODULE" desc="The text explaining the the installation of the extension was because of extensions that depend on this shared module">
            Installed because of dependent extension(s).
          </message>

--- a/patches/series
+++ b/patches/series
@@ -132,6 +132,7 @@ helium/core/sync/vault-store.patch
 helium/core/sync/loopback-server-in-memory.patch
 helium/core/sync/history-expiration-threshold.patch
 helium/core/sync/vault-engine-backend.patch
+helium/core/sync/provider/api-contract.patch
 
 helium/settings/setup-behavior-settings-page.patch
 helium/core/keyboard-shortcuts.patch


### PR DESCRIPTION
- add the browser.syncVaultProvider extension api, permission, disabled-by-default feature gate, install warning etc.
- define typed requests for provider configuration, vault discovery, conditional object storage, invalidations, cancellation, epoch collection, and account-bound key wrapping

Related: #90
