### PR TITLE
helium/core/sync: remove webidl from schema sources

### DIFF
--- a/patches/helium/core/sync/provider/api-contract.patch
+++ b/patches/helium/core/sync/provider/api-contract.patch
@@ -73,18 +73,14 @@
      "extension_types": ["extension", "platform_app"],
 --- a/chrome/common/extensions/api/api_sources.gni
 +++ b/chrome/common/extensions/api/api_sources.gni
-@@ -102,7 +102,10 @@ if (enable_extensions) {
+@@ -102,6 +102,7 @@ if (enable_extensions) {
    ]
  
    if (is_win || is_mac || is_linux) {
--    schema_sources_ += [ "web_authentication_proxy.webidl" ]
-+    schema_sources_ += [
-+      "sync_vault_provider.webidl",
-+      "web_authentication_proxy.webidl",
-+    ]
++    types_only_schema_sources_ += [ "sync_vault_provider.webidl" ]
+     schema_sources_ += [ "web_authentication_proxy.webidl" ]
    }
  
-   if (is_win || is_mac || is_linux || is_chromeos) {
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
 @@ -5557,6 +5557,9 @@ are declared in tools/grit/grit_args.gni


### PR DESCRIPTION
oops, too early