### PR TITLE
helium/ui: compact debugger warning, fix icon bubble margin

### DIFF
--- a/i18n/source.gen.json
+++ b/i18n/source.gen.json
@@ -1255,6 +1255,30 @@
     "message": "Manage fingerprinting protection"
   },
   {
+    "name": "IDS_EXTENSION_DEBUGGER_ACTIVE",
+    "source": "chrome/app/generated_resources.grd",
+    "context": "Label, tooltip, accessibility announcement, and bubble title shown after an extension starts debugging the browser.",
+    "message": "Debugging started"
+  },
+  {
+    "name": "IDS_EXTENSION_DEBUGGER_BUBBLE_MESSAGE",
+    "source": "chrome/app/generated_resources.grd",
+    "context": "Message shown above one or more extensions that are debugging the browser.",
+    "message": "{NUM_EXTENSIONS, plural,\n        =1 {This extension is debugging your browser:}\n        other {These extensions are debugging your browser:}}"
+  },
+  {
+    "name": "IDS_EXTENSION_DEBUGGER_STOP",
+    "source": "chrome/app/generated_resources.grd",
+    "context": "Tooltip and accessibility label for a button that stops an extension from debugging the browser.",
+    "message": "Stop <ph name=\"EXTENSION_NAME\">$1<ex>Extension Foo</ex></ph> from debugging your browser"
+  },
+  {
+    "name": "IDS_EXTENSION_DEBUGGER_STOP_BUTTON",
+    "source": "chrome/app/generated_resources.grd",
+    "context": "Label for a button that stops one extension from debugging the browser.",
+    "message": "Stop"
+  },
+  {
     "name": "IDS_CONTENT_CONTEXT_SYSTEM_TRANSLATE",
     "source": "chrome/app/generated_resources.grd",
     "context": "The name of the macOS system Translate command in the content area context menu",

--- a/patches/helium/ui/compact-debugger-warning.patch
+++ b/patches/helium/ui/compact-debugger-warning.patch
@@ -1,0 +1,890 @@
+--- a/chrome/app/vector_icons/BUILD.gn
++++ b/chrome/app/vector_icons/BUILD.gn
+@@ -70,6 +70,7 @@ aggregate_vector_icons("chrome_vector_ic
+     "browser_tools_update_chrome_refresh_old.icon",
+     "browser_tools_update_old.icon",
+     "brush_filled.icon",
++    "bug.icon",
+     "cast.icon",
+     "cast_chrome_refresh_old.icon",
+     "check.icon",
+--- /dev/null
++++ b/chrome/app/vector_icons/bug.icon
+@@ -0,0 +1,110 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++CANVAS_DIMENSIONS, 24,
++FILL_RULE_NONZERO,
++MOVE_TO, 12, 21,
++CUBIC_TO, 10.92f, 21, 9.91f, 20.73f, 8.99f, 20.2f,
++CUBIC_TO, 8.06f, 19.67f, 7.33f, 18.93f, 6.8f, 18,
++H_LINE_TO, 5,
++CUBIC_TO, 4.72f, 18, 4.48f, 17.9f, 4.29f, 17.71f,
++CUBIC_TO, 4.1f, 17.52f, 4, 17.28f, 4, 17,
++CUBIC_TO, 4, 16.72f, 4.1f, 16.48f, 4.29f, 16.29f,
++CUBIC_TO, 4.48f, 16.1f, 4.72f, 16, 5, 16,
++H_LINE_TO, 6.1f,
++CUBIC_TO, 6.05f, 15.67f, 6.02f, 15.33f, 6.01f, 15,
++CUBIC_TO, 6, 14.67f, 6, 14.33f, 6, 14,
++H_LINE_TO, 5,
++CUBIC_TO, 4.72f, 14, 4.48f, 13.9f, 4.29f, 13.71f,
++CUBIC_TO, 4.1f, 13.52f, 4, 13.28f, 4, 13,
++CUBIC_TO, 4, 12.72f, 4.1f, 12.48f, 4.29f, 12.29f,
++CUBIC_TO, 4.48f, 12.1f, 4.72f, 12, 5, 12,
++H_LINE_TO, 6,
++CUBIC_TO, 6, 11.67f, 6, 11.33f, 6.01f, 11,
++CUBIC_TO, 6.02f, 10.67f, 6.05f, 10.33f, 6.1f, 10,
++H_LINE_TO, 5,
++CUBIC_TO, 4.72f, 10, 4.48f, 9.9f, 4.29f, 9.71f,
++CUBIC_TO, 4.1f, 9.52f, 4, 9.28f, 4, 9,
++CUBIC_TO, 4, 8.72f, 4.1f, 8.48f, 4.29f, 8.29f,
++CUBIC_TO, 4.48f, 8.1f, 4.72f, 8, 5, 8,
++H_LINE_TO, 6.8f,
++CUBIC_TO, 7.03f, 7.62f, 7.3f, 7.26f, 7.59f, 6.92f,
++CUBIC_TO, 7.88f, 6.59f, 8.22f, 6.3f, 8.6f, 6.05f,
++LINE_TO, 7.68f, 5.1f,
++CUBIC_TO, 7.49f, 4.92f, 7.4f, 4.69f, 7.4f, 4.41f,
++CUBIC_TO, 7.4f, 4.14f, 7.5f, 3.9f, 7.7f, 3.7f,
++CUBIC_TO, 7.88f, 3.52f, 8.12f, 3.42f, 8.4f, 3.42f,
++CUBIC_TO, 8.68f, 3.42f, 8.92f, 3.52f, 9.1f, 3.7f,
++LINE_TO, 10.55f, 5.15f,
++CUBIC_TO, 11.02f, 5, 11.49f, 4.92f, 11.98f, 4.92f,
++CUBIC_TO, 12.46f, 4.92f, 12.93f, 5, 13.4f, 5.15f,
++LINE_TO, 14.9f, 3.67f,
++CUBIC_TO, 15.08f, 3.49f, 15.31f, 3.4f, 15.59f, 3.4f,
++CUBIC_TO, 15.86f, 3.4f, 16.1f, 3.5f, 16.3f, 3.7f,
++CUBIC_TO, 16.48f, 3.88f, 16.58f, 4.12f, 16.58f, 4.4f,
++CUBIC_TO, 16.58f, 4.68f, 16.48f, 4.92f, 16.3f, 5.1f,
++LINE_TO, 15.35f, 6.05f,
++CUBIC_TO, 15.73f, 6.3f, 16.08f, 6.59f, 16.39f, 6.91f,
++CUBIC_TO, 16.7f, 7.24f, 16.97f, 7.6f, 17.2f, 8,
++H_LINE_TO, 19,
++CUBIC_TO, 19.28f, 8, 19.52f, 8.1f, 19.71f, 8.29f,
++CUBIC_TO, 19.9f, 8.48f, 20, 8.72f, 20, 9,
++CUBIC_TO, 20, 9.28f, 19.9f, 9.52f, 19.71f, 9.71f,
++CUBIC_TO, 19.52f, 9.9f, 19.28f, 10, 19, 10,
++H_LINE_TO, 17.9f,
++CUBIC_TO, 17.95f, 10.33f, 17.98f, 10.67f, 17.99f, 11,
++CUBIC_TO, 18, 11.33f, 18, 11.67f, 18, 12,
++H_LINE_TO, 19,
++CUBIC_TO, 19.28f, 12, 19.52f, 12.1f, 19.71f, 12.29f,
++CUBIC_TO, 19.9f, 12.48f, 20, 12.72f, 20, 13,
++CUBIC_TO, 20, 13.28f, 19.9f, 13.52f, 19.71f, 13.71f,
++CUBIC_TO, 19.52f, 13.9f, 19.28f, 14, 19, 14,
++H_LINE_TO, 18,
++CUBIC_TO, 18, 14.33f, 18, 14.67f, 17.99f, 15,
++CUBIC_TO, 17.98f, 15.33f, 17.95f, 15.67f, 17.9f, 16,
++H_LINE_TO, 19,
++CUBIC_TO, 19.28f, 16, 19.52f, 16.1f, 19.71f, 16.29f,
++CUBIC_TO, 19.9f, 16.48f, 20, 16.72f, 20, 17,
++CUBIC_TO, 20, 17.28f, 19.9f, 17.52f, 19.71f, 17.71f,
++CUBIC_TO, 19.52f, 17.9f, 19.28f, 18, 19, 18,
++H_LINE_TO, 17.2f,
++CUBIC_TO, 16.67f, 18.93f, 15.94f, 19.67f, 15.01f, 20.2f,
++CUBIC_TO, 14.09f, 20.73f, 13.08f, 21, 12, 21,
++CLOSE,
++MOVE_TO, 12, 19,
++CUBIC_TO, 13.1f, 19, 14.04f, 18.61f, 14.83f, 17.83f,
++CUBIC_TO, 15.61f, 17.04f, 16, 16.1f, 16, 15,
++V_LINE_TO, 11,
++CUBIC_TO, 16, 9.9f, 15.61f, 8.96f, 14.83f, 8.17f,
++CUBIC_TO, 14.04f, 7.39f, 13.1f, 7, 12, 7,
++CUBIC_TO, 10.9f, 7, 9.96f, 7.39f, 9.18f, 8.17f,
++CUBIC_TO, 8.39f, 8.96f, 8, 9.9f, 8, 11,
++V_LINE_TO, 15,
++CUBIC_TO, 8, 16.1f, 8.39f, 17.04f, 9.18f, 17.83f,
++CUBIC_TO, 9.96f, 18.61f, 10.9f, 19, 12, 19,
++CLOSE,
++MOVE_TO, 11, 16,
++H_LINE_TO, 13,
++CUBIC_TO, 13.28f, 16, 13.52f, 15.9f, 13.71f, 15.71f,
++CUBIC_TO, 13.9f, 15.52f, 14, 15.28f, 14, 15,
++CUBIC_TO, 14, 14.72f, 13.9f, 14.48f, 13.71f, 14.29f,
++CUBIC_TO, 13.52f, 14.1f, 13.28f, 14, 13, 14,
++H_LINE_TO, 11,
++CUBIC_TO, 10.72f, 14, 10.48f, 14.1f, 10.29f, 14.29f,
++CUBIC_TO, 10.1f, 14.48f, 10, 14.72f, 10, 15,
++CUBIC_TO, 10, 15.28f, 10.1f, 15.52f, 10.29f, 15.71f,
++CUBIC_TO, 10.48f, 15.9f, 10.72f, 16, 11, 16,
++CLOSE,
++MOVE_TO, 11, 12,
++H_LINE_TO, 13,
++CUBIC_TO, 13.28f, 12, 13.52f, 11.9f, 13.71f, 11.71f,
++CUBIC_TO, 13.9f, 11.52f, 14, 11.28f, 14, 11,
++CUBIC_TO, 14, 10.72f, 13.9f, 10.48f, 13.71f, 10.29f,
++CUBIC_TO, 13.52f, 10.1f, 13.28f, 10, 13, 10,
++H_LINE_TO, 11,
++CUBIC_TO, 10.72f, 10, 10.48f, 10.1f, 10.29f, 10.29f,
++CUBIC_TO, 10.1f, 10.48f, 10, 10.72f, 10, 11,
++CUBIC_TO, 10, 11.28f, 10.1f, 11.52f, 10.29f, 11.71f,
++CUBIC_TO, 10.48f, 11.9f, 10.72f, 12, 11, 12,
++CLOSE
+--- a/chrome/app/generated_resources.grd
++++ b/chrome/app/generated_resources.grd
+@@ -4831,6 +4831,20 @@ are declared in tools/grit/grit_args.gni
+       <message name="IDS_DEV_TOOLS_INFOBAR_LABEL" desc="Label displayed in an infobar when external debugger is attached to the browser.  The label does not disappear until the user dismisses it, even if the debugger is detached, and so should not imply that the debugger must still be debugging the browser, only that it was, and could still be.">
+         "<ph name="CLIENT_NAME">$1<ex>Extension Foo</ex></ph>" started debugging this browser
+       </message>
++      <message name="IDS_EXTENSION_DEBUGGER_ACTIVE" desc="Label, tooltip, accessibility announcement, and bubble title shown after an extension starts debugging the browser.">
++        Debugging started
++      </message>
++      <message name="IDS_EXTENSION_DEBUGGER_BUBBLE_MESSAGE" desc="Message shown above one or more extensions that are debugging the browser.">
++        {NUM_EXTENSIONS, plural,
++        =1 {This extension is debugging your browser:}
++        other {These extensions are debugging your browser:}}
++      </message>
++      <message name="IDS_EXTENSION_DEBUGGER_STOP" desc="Tooltip and accessibility label for a button that stops an extension from debugging the browser.">
++        Stop <ph name="EXTENSION_NAME">$1<ex>Extension Foo</ex></ph> from debugging your browser
++      </message>
++      <message name="IDS_EXTENSION_DEBUGGER_STOP_BUTTON" desc="Label for a button that stops one extension from debugging the browser.">
++        Stop
++      </message>
+ 
+       <!-- DevTools file system access -->
+       <message name="IDS_DEV_TOOLS_CONFIRM_ADD_FILE_SYSTEM_MESSAGE" desc="Message displayed in DevTools infobar when user attempts to add file system to DevTools.">
+--- a/chrome/browser/extensions/api/debugger/BUILD.gn
++++ b/chrome/browser/extensions/api/debugger/BUILD.gn
+@@ -57,4 +57,27 @@ source_set("debugger") {
+     "//ui/gfx",
+     "//url",
+   ]
++
++  if (!is_android) {
++    deps += [
++      ":warning_status",
++      "//chrome/browser/ui:ui_features",
++    ]
++  }
++}
++
++if (!is_android) {
++  source_set("warning_status") {
++    sources = [
++      "extension_debugger_warning_status.cc",
++      "extension_debugger_warning_status.h",
++    ]
++
++    public_deps = [
++      "//base",
++      "//extensions/common",
++    ]
++
++    deps = [ "//chrome/browser/profiles:profile" ]
++  }
+ }
+--- /dev/null
++++ b/chrome/browser/extensions/api/debugger/extension_debugger_warning_status.cc
+@@ -0,0 +1,140 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++#include "chrome/browser/extensions/api/debugger/extension_debugger_warning_status.h"
++
++#include <memory>
++#include <string>
++#include <utility>
++#include <vector>
++
++#include "base/functional/bind.h"
++#include "base/strings/utf_string_conversions.h"
++#include "base/time/time.h"
++#include "base/timer/timer.h"
++#include "chrome/browser/profiles/profile.h"
++
++namespace extensions {
++
++namespace {
++
++// Profile uses this object's address to identify the stored status. The
++// integer value itself is never read.
++int kExtensionDebuggerWarningStatusKey;
++
++// Matches ExtensionDevToolsInfoBarDelegate::kAutoCloseDelay
++constexpr base::TimeDelta kAutoCloseDelay = base::Seconds(5);
++
++}  // namespace
++
++struct ExtensionDebuggerWarningStatus::ExtensionEntry {
++  ExtensionEntry(ExtensionDebuggerWarningStatus* owner,
++                 const ExtensionId& extension_id,
++                 std::u16string extension_name)
++      : extension_name(std::move(extension_name)) {
++    stop_callbacks.set_removal_callback(base::BindRepeating(
++        &ExtensionDebuggerWarningStatus::OnClientRemoved,
++        base::Unretained(owner), extension_id));
++  }
++
++  std::u16string extension_name;
++  base::OnceClosureList stop_callbacks;
++  base::OneShotTimer autoclose_timer;
++};
++
++ExtensionDebuggerWarningStatus::ExtensionDebuggerWarningStatus() = default;
++
++ExtensionDebuggerWarningStatus::~ExtensionDebuggerWarningStatus() = default;
++
++// static
++ExtensionDebuggerWarningStatus& ExtensionDebuggerWarningStatus::Get(
++    Profile& profile) {
++  auto* status = static_cast<ExtensionDebuggerWarningStatus*>(
++      profile.GetUserData(&kExtensionDebuggerWarningStatusKey));
++  if (!status) {
++    auto new_status = std::make_unique<ExtensionDebuggerWarningStatus>();
++    status = new_status.get();
++    profile.SetUserData(&kExtensionDebuggerWarningStatusKey,
++                        std::move(new_status));
++  }
++  return *status;
++}
++
++base::CallbackListSubscription ExtensionDebuggerWarningStatus::RegisterClient(
++    const ExtensionId& extension_id,
++    const std::string& extension_name,
++    base::OnceClosure stop_callback) {
++  std::u16string display_name = base::UTF8ToUTF16(extension_name);
++  auto [it, inserted] = entries_.try_emplace(extension_id);
++  if (inserted) {
++    it->second = std::make_unique<ExtensionEntry>(
++        this, extension_id, std::move(display_name));
++  } else {
++    it->second->autoclose_timer.Stop();
++    it->second->extension_name = std::move(display_name);
++  }
++
++  base::CallbackListSubscription subscription =
++      it->second->stop_callbacks.Add(std::move(stop_callback));
++
++  if (inserted) {
++    status_changed_callbacks_.Notify();
++  }
++  return subscription;
++}
++
++base::CallbackListSubscription
++ExtensionDebuggerWarningStatus::AddStatusChangedCallback(
++    base::RepeatingClosure state_changed_callback) {
++  return status_changed_callbacks_.Add(std::move(state_changed_callback));
++}
++
++bool ExtensionDebuggerWarningStatus::HasExtensions() const {
++  return !entries_.empty();
++}
++
++std::vector<ExtensionDebuggerWarningStatus::ExtensionInfo>
++ExtensionDebuggerWarningStatus::GetExtensions() const {
++  std::vector<ExtensionInfo> result;
++  for (const auto& [extension_id, entry] : entries_) {
++    result.push_back({extension_id, entry->extension_name});
++  }
++  return result;
++}
++
++void ExtensionDebuggerWarningStatus::StopExtension(
++    const ExtensionId& extension_id) {
++  const auto it = entries_.find(extension_id);
++  if (it != entries_.end()) {
++    it->second->stop_callbacks.Notify();
++    entries_.erase(it);
++    status_changed_callbacks_.Notify();
++  }
++}
++
++void ExtensionDebuggerWarningStatus::OnClientRemoved(
++    const ExtensionId& extension_id) {
++  const auto it = entries_.find(extension_id);
++  if (it == entries_.end() || !it->second->stop_callbacks.empty()) {
++    return;
++  }
++
++  it->second->autoclose_timer.Start(
++      FROM_HERE, kAutoCloseDelay,
++      base::BindOnce(&ExtensionDebuggerWarningStatus::OnAutocloseTimer,
++                     base::Unretained(this), extension_id));
++}
++
++void ExtensionDebuggerWarningStatus::OnAutocloseTimer(
++    const ExtensionId& extension_id) {
++  const auto it = entries_.find(extension_id);
++  if (it == entries_.end() || !it->second->stop_callbacks.empty()) {
++    return;
++  }
++
++  entries_.erase(it);
++  status_changed_callbacks_.Notify();
++}
++
++}  // namespace extensions
+--- /dev/null
++++ b/chrome/browser/extensions/api/debugger/extension_debugger_warning_status.h
+@@ -0,0 +1,65 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++#ifndef CHROME_BROWSER_EXTENSIONS_API_DEBUGGER_EXTENSION_DEBUGGER_WARNING_STATUS_H_
++#define CHROME_BROWSER_EXTENSIONS_API_DEBUGGER_EXTENSION_DEBUGGER_WARNING_STATUS_H_
++
++#include <map>
++#include <memory>
++#include <string>
++#include <vector>
++
++#include "base/callback_list.h"
++#include "base/functional/callback_forward.h"
++#include "base/supports_user_data.h"
++#include "extensions/common/extension_id.h"
++
++class Profile;
++
++namespace extensions {
++
++// Profile-wide state for extension debugger clients which require warning UI.
++class ExtensionDebuggerWarningStatus : public base::SupportsUserData::Data {
++ public:
++  struct ExtensionInfo {
++    ExtensionId extension_id;
++    std::u16string extension_name;
++  };
++
++  ExtensionDebuggerWarningStatus();
++  ExtensionDebuggerWarningStatus(const ExtensionDebuggerWarningStatus&) =
++      delete;
++  ExtensionDebuggerWarningStatus& operator=(
++      const ExtensionDebuggerWarningStatus&) = delete;
++  ~ExtensionDebuggerWarningStatus() override;
++
++  // Returns the lazily-created status owned by `profile`.
++  static ExtensionDebuggerWarningStatus& Get(Profile& profile);
++
++  base::CallbackListSubscription RegisterClient(
++      const ExtensionId& extension_id,
++      const std::string& extension_name,
++      base::OnceClosure stop_callback);
++  base::CallbackListSubscription AddStatusChangedCallback(
++      base::RepeatingClosure state_changed_callback);
++
++  bool HasExtensions() const;
++  std::vector<ExtensionInfo> GetExtensions() const;
++
++  // Stops every debugger client registered by `extension_id`.
++  void StopExtension(const ExtensionId& extension_id);
++
++ private:
++  struct ExtensionEntry;
++
++  void OnClientRemoved(const ExtensionId& extension_id);
++  void OnAutocloseTimer(const ExtensionId& extension_id);
++
++  std::map<ExtensionId, std::unique_ptr<ExtensionEntry>> entries_;
++  base::RepeatingClosureList status_changed_callbacks_;
++};
++
++}  // namespace extensions
++
++#endif  // CHROME_BROWSER_EXTENSIONS_API_DEBUGGER_EXTENSION_DEBUGGER_WARNING_STATUS_H_
+--- a/chrome/browser/extensions/api/debugger/debugger_api.cc
++++ b/chrome/browser/extensions/api/debugger/debugger_api.cc
+@@ -61,7 +61,10 @@
+ #if BUILDFLAG(IS_ANDROID)
+ #include "chrome/browser/extensions/api/debugger/extension_dev_tools_message_delegate.h"
+ #else
++#include "chrome/browser/extensions/api/debugger/extension_debugger_warning_status.h"
+ #include "chrome/browser/extensions/api/debugger/extension_dev_tools_infobar_delegate.h"
++#include "chrome/browser/ui/browser_window.h"
++#include "chrome/browser/ui/ui_features.h"
+ #endif
+ 
+ #if BUILDFLAG(ENABLE_EXTENSIONS)
+@@ -575,7 +578,25 @@ bool ExtensionDevToolsClientHost::Attach
+ #if BUILDFLAG(IS_ANDROID)
+     CreateWarningMessage();
+ #else
+-    CreateWarningInfobar();
++    WebContents* web_contents = agent_host_->GetWebContents();
++    BrowserWindow* browser_window =
++        web_contents
++            ? BrowserWindow::FindBrowserWindowWithWebContents(web_contents)
++            : nullptr;
++
++    // Fall back to infobar when the WebUI location bar is enabled or if there's
++    // no visible location bar.
++    if (::features::IsWebUILocationBarEnabled() ||
++        (browser_window && !browser_window->IsLocationBarVisible())) {
++      CreateWarningInfobar();
++    } else {
++      auto stop_debugging = base::BindOnce(
++          &ExtensionDevToolsClientHost::WarningUiDestroyed,
++          base::Unretained(this));
++      warning_infobar_subscription_ =
++          ExtensionDebuggerWarningStatus::Get(*profile_).RegisterClient(
++              extension_id(), extension_->name(), std::move(stop_debugging));
++    }
+ #endif
+   }
+ 
+--- a/chrome/browser/ui/views/location_bar/BUILD.gn
++++ b/chrome/browser/ui/views/location_bar/BUILD.gn
+@@ -80,6 +80,8 @@ source_set("impl") {
+     sources += [
+       "content_setting_image_view.cc",
+       "custom_tab_bar_view.cc",
++      "extension_debugger_warning_view.cc",
++      "extension_debugger_warning_view.h",
+       "lens_overlay_homework_page_action_controller.cc",
+       "location_bar_bubble_delegate_view.cc",
+       "location_bar_layout.cc",
+@@ -109,6 +111,7 @@ source_set("impl") {
+       "//chrome/browser/autocomplete:aim_eligibility_service",
+       "//chrome/browser/contextual_search",
+       "//chrome/browser/extensions",
++      "//chrome/browser/extensions/api/debugger:warning_status",
+       "//chrome/browser/extensions/api/omnibox",
+       "//chrome/browser/glic",
+       "//chrome/browser/history_embeddings",
+--- /dev/null
++++ b/chrome/browser/ui/views/location_bar/extension_debugger_warning_view.cc
+@@ -0,0 +1,255 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++#include "chrome/browser/ui/views/location_bar/extension_debugger_warning_view.h"
++
++#include <memory>
++#include <string>
++#include <utility>
++#include <vector>
++
++#include "base/functional/bind.h"
++#include "base/numerics/safe_conversions.h"
++#include "base/task/sequenced_task_runner.h"
++#include "chrome/app/vector_icons/vector_icons.h"
++#include "chrome/browser/extensions/api/debugger/extension_debugger_warning_status.h"
++#include "chrome/browser/profiles/profile.h"
++#include "chrome/browser/ui/color/chrome_color_id.h"
++#include "chrome/browser/ui/layout_constants.h"
++#include "chrome/browser/ui/views/chrome_layout_provider.h"
++#include "chrome/grit/generated_resources.h"
++#include "ui/accessibility/ax_enums.mojom.h"
++#include "ui/base/l10n/l10n_util.h"
++#include "ui/base/metadata/metadata_impl_macros.h"
++#include "ui/base/models/dialog_model.h"
++#include "ui/base/models/image_model.h"
++#include "ui/gfx/text_constants.h"
++#include "ui/views/accessibility/view_accessibility.h"
++#include "ui/views/border.h"
++#include "ui/views/bubble/bubble_dialog_model_host.h"
++#include "ui/views/controls/button/md_text_button.h"
++#include "ui/views/controls/label.h"
++#include "ui/views/layout/box_layout.h"
++#include "ui/views/layout/box_layout_view.h"
++#include "ui/views/layout/layout_provider.h"
++#include "ui/views/style/typography.h"
++#include "ui/views/widget/widget.h"
++
++namespace extensions {
++
++namespace {
++
++void StopExtensionNow(base::WeakPtr<Profile> profile,
++                      ExtensionId extension_id) {
++  if (profile) {
++    ExtensionDebuggerWarningStatus::Get(*profile).StopExtension(extension_id);
++  }
++}
++
++void StopExtension(base::WeakPtr<Profile> profile,
++                   ExtensionId extension_id) {
++  // Detaching can synchronously close the bubble through its status observer.
++  base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
++      FROM_HERE, base::BindOnce(&StopExtensionNow, std::move(profile),
++                                std::move(extension_id)));
++}
++
++std::unique_ptr<views::View> CreateExtensionRow(
++    base::WeakPtr<Profile> profile,
++    const ExtensionDebuggerWarningStatus::ExtensionInfo& extension) {
++  auto row = std::make_unique<views::BoxLayoutView>();
++  row->SetOrientation(views::BoxLayout::Orientation::kHorizontal);
++  row->SetCrossAxisAlignment(views::BoxLayout::CrossAxisAlignment::kCenter);
++  row->SetBetweenChildSpacing(
++      ChromeLayoutProvider::Get()->GetDistanceMetric(
++          views::DISTANCE_RELATED_CONTROL_HORIZONTAL));
++
++  auto label = std::make_unique<views::Label>(
++      extension.extension_name, views::style::CONTEXT_LABEL,
++      views::style::STYLE_PRIMARY);
++  label->SetHorizontalAlignment(gfx::ALIGN_LEFT);
++  label->SetAllowCharacterBreak(true);
++  label->SetElideBehavior(gfx::NO_ELIDE);
++  label->SetMultiLine(true);
++  views::Label* label_ptr = row->AddChildView(std::move(label));
++  row->SetFlexForView(label_ptr, 1);
++
++  const std::u16string accessible_name = l10n_util::GetStringFUTF16(
++      IDS_EXTENSION_DEBUGGER_STOP, extension.extension_name);
++  auto button = std::make_unique<views::MdTextButton>(
++      base::BindRepeating(&StopExtension, std::move(profile),
++                          extension.extension_id),
++      l10n_util::GetStringUTF16(IDS_EXTENSION_DEBUGGER_STOP_BUTTON));
++  button->SetTooltipText(accessible_name);
++  button->GetViewAccessibility().SetName(accessible_name);
++  row->AddChildView(std::move(button));
++  return row;
++}
++
++void RebuildExtensionRows(
++    Profile& profile,
++    const std::vector<ExtensionDebuggerWarningStatus::ExtensionInfo>&
++        extension_infos,
++    views::BoxLayoutView& extension_list) {
++  extension_list.RemoveAllChildViews();
++  base::WeakPtr<Profile> profile_weak = profile.GetWeakPtr();
++  for (const auto& extension : extension_infos) {
++    extension_list.AddChildView(CreateExtensionRow(profile_weak, extension));
++  }
++}
++
++std::unique_ptr<views::BoxLayoutView> CreateExtensionList(
++    Profile& profile,
++    const std::vector<ExtensionDebuggerWarningStatus::ExtensionInfo>&
++        extension_infos) {
++  auto extension_list = std::make_unique<views::BoxLayoutView>();
++  extension_list->SetOrientation(views::BoxLayout::Orientation::kVertical);
++  extension_list->SetCrossAxisAlignment(
++      views::BoxLayout::CrossAxisAlignment::kStretch);
++  extension_list->SetBetweenChildSpacing(
++      ChromeLayoutProvider::Get()->GetDistanceMetric(
++          views::DISTANCE_CONTROL_LIST_VERTICAL));
++  RebuildExtensionRows(profile, extension_infos, *extension_list);
++  return extension_list;
++}
++
++std::unique_ptr<views::BubbleDialogModelHost>
++CreateExtensionDebuggerWarningBubble(
++    views::View* anchor_view,
++    int extension_count,
++    std::unique_ptr<views::BoxLayoutView> extension_list) {
++  auto dialog_model =
++      ui::DialogModel::Builder()
++          .SetInternalName("ExtensionDebuggerWarningBubble")
++          .SetTitle(l10n_util::GetStringUTF16(IDS_EXTENSION_DEBUGGER_ACTIVE))
++          .SetIsAlertDialog()
++          .OverrideShowCloseButton(true)
++          .AddParagraph(
++              ui::DialogModelLabel(l10n_util::GetPluralStringFUTF16(
++                  IDS_EXTENSION_DEBUGGER_BUBBLE_MESSAGE, extension_count))
++                  .set_allow_character_break())
++          .AddCustomField(
++              std::make_unique<views::BubbleDialogModelHost::CustomView>(
++                  std::move(extension_list),
++                  views::BubbleDialogModelHost::FieldType::kControl))
++          .Build();
++
++  auto bubble = std::make_unique<views::BubbleDialogModelHost>(
++      std::move(dialog_model), anchor_view, views::BubbleBorder::TOP_LEFT);
++  bubble->set_fixed_width(views::LayoutProvider::Get()->GetDistanceMetric(
++      views::DISTANCE_BUBBLE_PREFERRED_WIDTH));
++  return bubble;
++}
++
++}  // namespace
++
++ExtensionDebuggerWarningView::ExtensionDebuggerWarningView(
++    Profile& profile,
++    IconLabelBubbleView::Delegate* parent_delegate,
++    const gfx::FontList& font_list)
++    : IconLabelBubbleView(font_list, parent_delegate), profile_(profile) {
++  SetUpForInOutAnimation();
++  label()->SetTextContext(views::style::CONTEXT_BUTTON_MD);
++  label()->SetTextStyle(views::style::STYLE_BODY_4_EMPHASIS);
++  SetBackgroundVisibility(BackgroundVisibility::kAlways);
++  SetCustomBackgroundColorId(
++      kColorOmniboxChipInUseActivityIndicatorBackground);
++  SetCustomForegroundColorId(
++      kColorOmniboxChipInUseActivityIndicatorForeground);
++  SetImageModel(ui::ImageModel::FromVectorIcon(
++      kBugIcon, kColorOmniboxChipInUseActivityIndicatorForeground,
++      GetLayoutConstant(LayoutConstant::kLocationBarLeadingIconSize)));
++  UpdateBorder();
++  SetTooltipText(
++      l10n_util::GetStringUTF16(IDS_EXTENSION_DEBUGGER_ACTIVE));
++  GetViewAccessibility().SetHasPopup(ax::mojom::HasPopup::kDialog);
++  SetVisible(false);
++
++  status_changed_subscription_ =
++      ExtensionDebuggerWarningStatus::Get(profile_.get())
++          .AddStatusChangedCallback(base::BindRepeating(
++              &ExtensionDebuggerWarningView::OnStatusChanged,
++              weak_factory_.GetWeakPtr()));
++  OnStatusChanged();
++}
++
++ExtensionDebuggerWarningView::~ExtensionDebuggerWarningView() = default;
++
++bool ExtensionDebuggerWarningView::ShouldShowSeparator() const {
++  return false;
++}
++
++bool ExtensionDebuggerWarningView::ShowBubble(const ui::Event&) {
++  if (bubble_) {
++    return true;
++  }
++
++  const auto extension_infos =
++      ExtensionDebuggerWarningStatus::Get(profile_.get()).GetExtensions();
++  if (extension_infos.empty()) {
++    return false;
++  }
++
++  auto extension_list = CreateExtensionList(profile_.get(), extension_infos);
++  extension_list_ = extension_list.get();
++
++  auto bubble = CreateExtensionDebuggerWarningBubble(
++      this, base::checked_cast<int>(extension_infos.size()),
++      std::move(extension_list));
++  bubble_ = bubble.get();
++  bubble_->RegisterWindowClosingCallback(base::BindOnce(
++      &ExtensionDebuggerWarningView::OnBubbleClosing,
++      weak_factory_.GetWeakPtr()));
++  views::BubbleDialogDelegate::CreateBubbleDeprecated(
++      std::move(bubble),
++      views::Widget::InitParams::NATIVE_WIDGET_OWNS_WIDGET)
++      ->Show();
++  return true;
++}
++
++bool ExtensionDebuggerWarningView::IsBubbleShowing() const {
++  return bubble_ != nullptr;
++}
++
++void ExtensionDebuggerWarningView::UpdateBorder() {
++  SetBorder(views::CreateEmptyBorder(
++      GetLayoutInsets(LOCATION_BAR_PAGE_INFO_ICON_PADDING)));
++}
++
++void ExtensionDebuggerWarningView::OnStatusChanged() {
++  const auto extension_infos =
++      ExtensionDebuggerWarningStatus::Get(profile_.get()).GetExtensions();
++  const bool should_show = !extension_infos.empty();
++
++  if (bubble_) {
++    if (should_show) {
++      RebuildExtensionRows(profile_.get(), extension_infos, *extension_list_);
++    } else {
++      bubble_->Close();
++    }
++  }
++  if (GetVisible() == should_show) {
++    return;
++  }
++
++  if (should_show) {
++    SetVisible(true);
++    ResetSlideAnimation(false);
++    AnimateIn(IDS_EXTENSION_DEBUGGER_ACTIVE);
++  } else {
++    ResetSlideAnimation(false);
++    SetVisible(false);
++  }
++  PreferredSizeChanged();
++}
++
++void ExtensionDebuggerWarningView::OnBubbleClosing() {
++  bubble_ = nullptr;
++  extension_list_ = nullptr;
++}
++
++BEGIN_METADATA(ExtensionDebuggerWarningView)
++END_METADATA
++
++}  // namespace extensions
+--- /dev/null
++++ b/chrome/browser/ui/views/location_bar/extension_debugger_warning_view.h
+@@ -0,0 +1,60 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++#ifndef CHROME_BROWSER_UI_VIEWS_LOCATION_BAR_EXTENSION_DEBUGGER_WARNING_VIEW_H_
++#define CHROME_BROWSER_UI_VIEWS_LOCATION_BAR_EXTENSION_DEBUGGER_WARNING_VIEW_H_
++
++#include "base/callback_list.h"
++#include "base/memory/raw_ptr.h"
++#include "base/memory/raw_ref.h"
++#include "base/memory/weak_ptr.h"
++#include "chrome/browser/ui/views/location_bar/icon_label_bubble_view.h"
++#include "ui/base/metadata/metadata_header_macros.h"
++
++class Profile;
++
++namespace gfx {
++class FontList;
++}
++
++namespace views {
++class BubbleDialogModelHost;
++class BoxLayoutView;
++}
++
++namespace extensions {
++
++class ExtensionDebuggerWarningView : public IconLabelBubbleView {
++  METADATA_HEADER(ExtensionDebuggerWarningView, IconLabelBubbleView)
++
++ public:
++  ExtensionDebuggerWarningView(
++      Profile& profile,
++      IconLabelBubbleView::Delegate* parent_delegate,
++      const gfx::FontList& font_list);
++  ExtensionDebuggerWarningView(const ExtensionDebuggerWarningView&) = delete;
++  ExtensionDebuggerWarningView& operator=(
++      const ExtensionDebuggerWarningView&) = delete;
++  ~ExtensionDebuggerWarningView() override;
++
++ private:
++  // IconLabelBubbleView:
++  bool ShouldShowSeparator() const override;
++  bool ShowBubble(const ui::Event& event) override;
++  bool IsBubbleShowing() const override;
++  void UpdateBorder() override;
++
++  void OnStatusChanged();
++  void OnBubbleClosing();
++
++  const raw_ref<Profile> profile_;
++  raw_ptr<views::BubbleDialogModelHost> bubble_ = nullptr;
++  raw_ptr<views::BoxLayoutView> extension_list_ = nullptr;
++  base::CallbackListSubscription status_changed_subscription_;
++  base::WeakPtrFactory<ExtensionDebuggerWarningView> weak_factory_{this};
++};
++
++}  // namespace extensions
++
++#endif  // CHROME_BROWSER_UI_VIEWS_LOCATION_BAR_EXTENSION_DEBUGGER_WARNING_VIEW_H_
+--- a/chrome/browser/ui/views/location_bar/location_bar_view.h
++++ b/chrome/browser/ui/views/location_bar/location_bar_view.h
+@@ -58,6 +58,10 @@ class ActionItem;
+ class ActionInvocationContext;
+ }  // namespace actions
+ 
++namespace extensions {
++class ExtensionDebuggerWarningView;
++}  // namespace extensions
++
+ namespace omnibox {
+ enum ToolMode : int;
+ enum ModelMode : int;
+@@ -581,6 +585,8 @@ class LocationBarView
+   // An icon to the left of the edit field: the HTTPS lock, blank page icon,
+   // search icon, EV HTTPS bubble, etc.
+   raw_ptr<LocationIconView> location_icon_view_ = nullptr;
++  raw_ptr<extensions::ExtensionDebuggerWarningView>
++      extension_debugger_warning_view_ = nullptr;
+ 
+   // Views to show inline autocompletion when an IME is active.  In this case,
+   // we shouldn't change the text or selection inside the OmniboxView itself,
+--- a/chrome/browser/ui/views/location_bar/location_bar_view.cc
++++ b/chrome/browser/ui/views/location_bar/location_bar_view.cc
+@@ -61,6 +61,7 @@
+ #include "chrome/browser/ui/views/chrome_typography.h"
+ #include "chrome/browser/ui/views/frame/browser_view.h"
+ #include "chrome/browser/ui/views/location_bar/content_setting_image_view.h"
++#include "chrome/browser/ui/views/location_bar/extension_debugger_warning_view.h"
+ #include "chrome/browser/ui/views/location_bar/location_bar_layout.h"
+ #include "chrome/browser/ui/views/location_bar/location_bar_util.h"
+ #include "chrome/browser/ui/views/location_bar/location_icon_view.h"
+@@ -455,6 +456,11 @@ void LocationBarView::Init() {
+   selected_keyword_view_ = AddChildView(std::make_unique<SelectedKeywordView>(
+       this, profile_, omnibox_controller_.get(), font_list));
+ 
++  if (browser_) {
++    extension_debugger_warning_view_ = AddChildView(
++        std::make_unique<extensions::ExtensionDebuggerWarningView>(
++            *profile_, this, omnibox_chip_font_list));
++  }
+ 
+   SkColor icon_color = color_provider->GetColor(kColorOmniboxResultsIcon);
+ 
+@@ -846,6 +852,16 @@ void LocationBarView::Layout(PassKey) {
+   // The largest fraction of the omnibox that can be taken by the EV or search
+   // label/chip.
+   const double kLeadingDecorationMaxFraction = 0.5;
++  const int leading_intra_padding =
++      GetLayoutConstant(LayoutConstant::kLocationBarElementPadding);
++
++  if (extension_debugger_warning_view_ &&
++      extension_debugger_warning_view_->GetVisible()) {
++    leading_decorations.AddDecoration(
++        vertical_padding, location_height, /*auto_collapse=*/false,
++        /*max_fraction=*/0, /*intra_item_padding=*/0, icon_left,
++        extension_debugger_warning_view_);
++  }
+ 
+   const bool show_overriding_permission_chip =
+       base::FeatureList::IsEnabled(
+@@ -858,7 +874,8 @@ void LocationBarView::Layout(PassKey) {
+     if (base::FeatureList::IsEnabled(
+             content_settings::features::kLeftHandSideActivityIndicators)) {
+       leading_decorations.AddDecoration(vertical_padding, location_height,
+-                                        false, 0, /*intra_item_padding=*/0,
++                                        false, 0,
++                                        leading_intra_padding,
+                                         icon_left, permission_dashboard_view_);
+     } else {
+       CHECK(chip_view_);
+@@ -872,18 +889,18 @@ void LocationBarView::Layout(PassKey) {
+     location_icon_view_->SetVisible(false);
+     leading_decorations.AddDecoration(
+         vertical_padding, location_height, false, kLeadingDecorationMaxFraction,
+-        /*intra_item_padding=*/0, icon_left, selected_keyword_view_);
++        leading_intra_padding, icon_left, selected_keyword_view_);
+     selected_keyword_view_->SetKeyword(keyword);
+   } else if (location_icon_view_->GetShowText() &&
+              !ShouldChipOverrideLocationIcon()) {
+     location_icon_view_->SetVisible(true);
+     leading_decorations.AddDecoration(
+         vertical_padding, location_height, false, kLeadingDecorationMaxFraction,
+-        /*intra_item_padding=*/0, icon_left, location_icon_view_);
++        leading_intra_padding, icon_left, location_icon_view_);
+   } else if (!ShouldChipOverrideLocationIcon()) {
+     location_icon_view_->SetVisible(true);
+     leading_decorations.AddDecoration(vertical_padding, location_height, false,
+-                                      0, /*intra_item_padding=*/0, icon_left,
++                                      0, leading_intra_padding, icon_left,
+                                       location_icon_view_);
+   } else {
+     location_icon_view_->SetVisible(false);
+@@ -1435,17 +1452,26 @@ int LocationBarView::GetAvailableDecorat
+ }
+ 
+ int LocationBarView::GetMinimumLeadingWidth() const {
++  const int debugger_intra_padding =
++      extension_debugger_warning_view_ &&
++              extension_debugger_warning_view_->GetVisible()
++          ? GetLayoutConstant(LayoutConstant::kLocationBarElementPadding)
++          : 0;
++  const int debugger_width =
++      IncrementalMinimumWidth(extension_debugger_warning_view_) +
++      debugger_intra_padding;
++
+   // If the keyword bubble is showing, the view can collapse completely.
+   if (ShouldShowKeywordBubble()) {
+-    return 0;
++    return debugger_width;
+   }
+ 
+   if (location_icon_view_->GetShowText()) {
+-    return location_icon_view_->GetMinimumLabelTextWidth();
++    return location_icon_view_->GetMinimumLabelTextWidth() + debugger_width;
+   }
+ 
+   return GetLayoutConstant(LayoutConstant::kLocationBarElementPadding) +
+-         location_icon_view_->GetMinimumSize().width();
++         location_icon_view_->GetMinimumSize().width() + debugger_width;
+ }
+ 
+ int LocationBarView::GetMinimumTrailingWidth() const {

--- a/patches/helium/ui/location-bar.patch
+++ b/patches/helium/ui/location-bar.patch
@@ -22,7 +22,23 @@
  }
  
  void IconLabelBubbleView::SetCornerRadii(const gfx::RoundedCornersF& radii) {
-@@ -802,12 +802,12 @@ SkPath IconLabelBubbleView::GetHighlight
+@@ -618,8 +618,14 @@ gfx::Size IconLabelBubbleView::GetSizeFo
+ 
+   const int min_width =
+       shrinking ? image_size.width() : grow_animation_starting_width_;
++  // Match the icon-to-label spacing without shifting collapsed icons.
++  const int expanded_label_trailing_padding =
++      ShouldShowSeparator()
++          ? 0
++          : std::max(0, GetInternalSpacing() - GetInsets().right());
+   const int max_width = image_size.width() + GetInternalSpacing() +
+-                        label_width + expanded_label_additional_insets_.size();
++                        label_width + expanded_label_additional_insets_.size() +
++                        expanded_label_trailing_padding;
+ 
+   return gfx::Size(GetWidthBetween(min_width, max_width), image_size.height());
+ }
+@@ -802,12 +808,12 @@ SkPath IconLabelBubbleView::GetHighlight
    highlight_bounds = GetMirroredRect(highlight_bounds);
  
    const SkRect rect = RectToSkRect(highlight_bounds);

--- a/patches/series
+++ b/patches/series
@@ -349,3 +349,4 @@ helium/ui/page-zoom-indicator.patch
 helium/ui/add-more-zoom-presets.patch
 helium/ui/helium-noise-page-info.patch
 helium/ui/show-tabs-from-non-account-backends.patch
+helium/ui/compact-debugger-warning.patch


### PR DESCRIPTION
this PR converts an extension debugging warning infobar into a location bar icon bubble and a small informational popup:
- the icon bubble is always present while debugging is active.
- the warning sticks around for 5 seconds after debugging is done, just like the infobar.
- lists all extensions with active debugging sessions, lets the user kill them one by one.
- after initial "Debugging started" alert, only a tiny activity indicator stays on screen.
- falls back to infobar when no native location bar is available (such as in installed PWA).

this PR also fixes uneven visual margin in camera/mic activity alerts.

closes https://github.com/imputnet/helium/issues/2264

https://github.com/user-attachments/assets/91c7eb20-1486-429d-863e-aeccf33a0851

https://github.com/user-attachments/assets/461ecb8f-aefa-4ff1-8333-3494a9d2993e

