### PR TITLE
helium/core/sync/vault: use provider-neutral engine names

### DIFF
--- a/patches/helium/core/sync/vault-encryption.patch
+++ b/patches/helium/core/sync/vault-encryption.patch
@@ -1,8 +1,8 @@
---- a/components/sync/engine/extension_sync/BUILD.gn
-+++ b/components/sync/engine/extension_sync/BUILD.gn
+--- a/components/sync/engine/sync_vault/BUILD.gn
++++ b/components/sync/engine/sync_vault/BUILD.gn
 @@ -11,12 +11,17 @@ proto_library("sync_vault_proto") {
  
- source_set("extension_sync") {
+ source_set("sync_vault") {
    sources = [
 +    "sync_vault_cryptographer.cc",
 +    "sync_vault_cryptographer.h",
@@ -20,13 +20,13 @@
    deps = [ ":sync_vault_proto" ]
  }
 --- /dev/null
-+++ b/components/sync/engine/extension_sync/sync_vault_cryptographer.cc
++++ b/components/sync/engine/sync_vault/sync_vault_cryptographer.cc
 @@ -0,0 +1,146 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
 +
-+#include "components/sync/engine/extension_sync/sync_vault_cryptographer.h"
++#include "components/sync/engine/sync_vault/sync_vault_cryptographer.h"
 +
 +#include <array>
 +#include <cstdint>
@@ -169,14 +169,14 @@
 +
 +}  // namespace syncer
 --- /dev/null
-+++ b/components/sync/engine/extension_sync/sync_vault_cryptographer.h
++++ b/components/sync/engine/sync_vault/sync_vault_cryptographer.h
 @@ -0,0 +1,75 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
 +
-+#ifndef COMPONENTS_SYNC_ENGINE_EXTENSION_SYNC_SYNC_VAULT_CRYPTOGRAPHER_H_
-+#define COMPONENTS_SYNC_ENGINE_EXTENSION_SYNC_SYNC_VAULT_CRYPTOGRAPHER_H_
++#ifndef COMPONENTS_SYNC_ENGINE_SYNC_VAULT_SYNC_VAULT_CRYPTOGRAPHER_H_
++#define COMPONENTS_SYNC_ENGINE_SYNC_VAULT_SYNC_VAULT_CRYPTOGRAPHER_H_
 +
 +#include <cstddef>
 +#include <cstdint>
@@ -186,7 +186,7 @@
 +
 +#include "base/containers/span.h"
 +#include "base/types/expected.h"
-+#include "components/sync/engine/extension_sync/sync_vault_limits.h"
++#include "components/sync/engine/sync_vault/sync_vault_limits.h"
 +#include "crypto/aead.h"
 +
 +namespace syncer {
@@ -245,4 +245,4 @@
 +
 +}  // namespace syncer
 +
-+#endif  // COMPONENTS_SYNC_ENGINE_EXTENSION_SYNC_SYNC_VAULT_CRYPTOGRAPHER_H_
++#endif  // COMPONENTS_SYNC_ENGINE_SYNC_VAULT_SYNC_VAULT_CRYPTOGRAPHER_H_

--- a/patches/helium/core/sync/vault-engine-backend.patch
+++ b/patches/helium/core/sync/vault-engine-backend.patch
@@ -4,10 +4,10 @@
      "events/protocol_event_buffer.cc",
      "events/protocol_event_buffer.h",
      "events/protocol_event_observer.h",
-+    "extension_sync/extension_sync_backend.cc",
-+    "extension_sync/extension_sync_backend.h",
-+    "extension_sync/extension_sync_connection_manager.cc",
-+    "extension_sync/extension_sync_connection_manager.h",
++    "sync_vault/sync_vault_backend.cc",
++    "sync_vault/sync_vault_backend.h",
++    "sync_vault/sync_vault_connection_manager.cc",
++    "sync_vault/sync_vault_connection_manager.h",
      "forwarding_data_type_processor.cc",
      "forwarding_data_type_processor.h",
      "get_updates_delegate.cc",
@@ -15,63 +15,63 @@
      "//base",
      "//components/signin/public/identity_manager",
      "//components/sync/base",
-+    "//components/sync/engine/extension_sync",
++    "//components/sync/engine/sync_vault",
      "//components/sync/protocol",
      "//components/sync/protocol:util",
      "//net",
 --- /dev/null
-+++ b/components/sync/engine/extension_sync/extension_sync_backend.cc
++++ b/components/sync/engine/sync_vault/sync_vault_backend.cc
 @@ -0,0 +1,36 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
 +
-+#include "components/sync/engine/extension_sync/extension_sync_backend.h"
++#include "components/sync/engine/sync_vault/sync_vault_backend.h"
 +
 +#include <memory>
 +#include <utility>
 +
 +#include "base/check.h"
-+#include "components/sync/engine/extension_sync/extension_sync_connection_manager.h"
-+#include "components/sync/engine/extension_sync/sync_vault_store.h"
++#include "components/sync/engine/sync_vault/sync_vault_connection_manager.h"
++#include "components/sync/engine/sync_vault/sync_vault_store.h"
 +
 +namespace syncer {
 +
-+ExtensionSyncBackend::ExtensionSyncBackend(
++SyncVaultBackend::SyncVaultBackend(
 +    std::unique_ptr<SyncVaultStore> vault_store,
-+    ExtensionSyncDiagnosticsCallback diagnostics_callback)
++    SyncVaultDiagnosticsCallback diagnostics_callback)
 +    : vault_store_(std::move(vault_store)),
 +      diagnostics_callback_(std::move(diagnostics_callback)) {
 +  CHECK(vault_store_);
 +}
 +
-+ExtensionSyncBackend::~ExtensionSyncBackend() = default;
++SyncVaultBackend::~SyncVaultBackend() = default;
 +
 +std::unique_ptr<ServerConnectionManager>
-+ExtensionSyncBackend::CreateConnectionManager(
++SyncVaultBackend::CreateConnectionManager(
 +    CancelationSignal* cancelation_signal) {
 +  CHECK(vault_store_);
 +  CHECK(cancelation_signal);
 +  vault_store_->SetCancelationSignal(cancelation_signal);
-+  return std::make_unique<ExtensionSyncConnectionManager>(
++  return std::make_unique<SyncVaultConnectionManager>(
 +      std::move(vault_store_), std::move(diagnostics_callback_));
 +}
 +
 +}  // namespace syncer
 --- /dev/null
-+++ b/components/sync/engine/extension_sync/extension_sync_backend.h
++++ b/components/sync/engine/sync_vault/sync_vault_backend.h
 @@ -0,0 +1,39 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
 +
-+#ifndef COMPONENTS_SYNC_ENGINE_EXTENSION_SYNC_EXTENSION_SYNC_BACKEND_H_
-+#define COMPONENTS_SYNC_ENGINE_EXTENSION_SYNC_EXTENSION_SYNC_BACKEND_H_
++#ifndef COMPONENTS_SYNC_ENGINE_SYNC_VAULT_SYNC_VAULT_BACKEND_H_
++#define COMPONENTS_SYNC_ENGINE_SYNC_VAULT_SYNC_VAULT_BACKEND_H_
 +
 +#include <memory>
 +
 +#include "components/sync/engine/custom_sync_backend.h"
-+#include "components/sync/engine/extension_sync/extension_sync_connection_manager.h"
++#include "components/sync/engine/sync_vault/sync_vault_connection_manager.h"
 +
 +namespace syncer {
 +
@@ -79,35 +79,35 @@
 +class SyncVaultStore;
 +
 +// Adapts the private vault journal to the generic custom backend boundary.
-+class ExtensionSyncBackend final : public CustomSyncBackend {
++class SyncVaultBackend final : public CustomSyncBackend {
 + public:
-+  explicit ExtensionSyncBackend(
++  explicit SyncVaultBackend(
 +      std::unique_ptr<SyncVaultStore> vault_store,
-+      ExtensionSyncDiagnosticsCallback diagnostics_callback = {});
-+  ~ExtensionSyncBackend() override;
++      SyncVaultDiagnosticsCallback diagnostics_callback = {});
++  ~SyncVaultBackend() override;
 +
-+  ExtensionSyncBackend(const ExtensionSyncBackend&) = delete;
-+  ExtensionSyncBackend& operator=(const ExtensionSyncBackend&) = delete;
++  SyncVaultBackend(const SyncVaultBackend&) = delete;
++  SyncVaultBackend& operator=(const SyncVaultBackend&) = delete;
 +
 +  std::unique_ptr<ServerConnectionManager> CreateConnectionManager(
 +      CancelationSignal* cancelation_signal) override;
 +
 + private:
 +  std::unique_ptr<SyncVaultStore> vault_store_;
-+  ExtensionSyncDiagnosticsCallback diagnostics_callback_;
++  SyncVaultDiagnosticsCallback diagnostics_callback_;
 +};
 +
 +}  // namespace syncer
 +
-+#endif  // COMPONENTS_SYNC_ENGINE_EXTENSION_SYNC_EXTENSION_SYNC_BACKEND_H_
++#endif  // COMPONENTS_SYNC_ENGINE_SYNC_VAULT_SYNC_VAULT_BACKEND_H_
 --- /dev/null
-+++ b/components/sync/engine/extension_sync/extension_sync_connection_manager.cc
++++ b/components/sync/engine/sync_vault/sync_vault_connection_manager.cc
 @@ -0,0 +1,191 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
 +
-+#include "components/sync/engine/extension_sync/extension_sync_connection_manager.h"
++#include "components/sync/engine/sync_vault/sync_vault_connection_manager.h"
 +
 +#include <memory>
 +#include <optional>
@@ -132,17 +132,17 @@
 +
 +}  // namespace
 +
-+ExtensionSyncConnectionManager::ExtensionSyncConnectionManager(
++SyncVaultConnectionManager::SyncVaultConnectionManager(
 +    std::unique_ptr<SyncVaultStore> vault_store,
-+    ExtensionSyncDiagnosticsCallback diagnostics_callback)
++    SyncVaultDiagnosticsCallback diagnostics_callback)
 +    : vault_store_(std::move(vault_store)),
 +      diagnostics_callback_(std::move(diagnostics_callback)) {
 +  CHECK(vault_store_);
 +}
 +
-+ExtensionSyncConnectionManager::~ExtensionSyncConnectionManager() = default;
++SyncVaultConnectionManager::~SyncVaultConnectionManager() = default;
 +
-+HttpResponse ExtensionSyncConnectionManager::PostBuffer(
++HttpResponse SyncVaultConnectionManager::PostBuffer(
 +    const std::string& buffer_in,
 +    std::string* buffer_out) {
 +  CHECK(buffer_out);
@@ -242,7 +242,7 @@
 +      buffer_out->clear();
 +      return HttpResponse::ForHttpStatusCode(net::HTTP_INTERNAL_SERVER_ERROR);
 +    }
-+    ReportDiagnostics(std::nullopt, ExtensionSyncStateDiagnostics{
++    ReportDiagnostics(std::nullopt, SyncVaultStateDiagnostics{
 +                                        loopback_server_->GetEntityCount(),
 +                                        loaded_state_->data.size()});
 +    return HttpResponse::ForHttpStatusCode(net::HTTP_OK);
@@ -251,7 +251,7 @@
 +  return ResponseForVaultError(SyncVaultStoreError::kConflict);
 +}
 +
-+HttpResponse ExtensionSyncConnectionManager::ResponseForVaultError(
++HttpResponse SyncVaultConnectionManager::ResponseForVaultError(
 +    SyncVaultStoreError error) {
 +  ReportDiagnostics(error);
 +  switch (error) {
@@ -285,9 +285,9 @@
 +  return HttpResponse::ForUnspecifiedError();
 +}
 +
-+void ExtensionSyncConnectionManager::ReportDiagnostics(
++void SyncVaultConnectionManager::ReportDiagnostics(
 +    std::optional<SyncVaultStoreError> error,
-+    std::optional<ExtensionSyncStateDiagnostics> state) {
++    std::optional<SyncVaultStateDiagnostics> state) {
 +  if (diagnostics_callback_) {
 +    diagnostics_callback_.Run(error, vault_store_->checkpoint(), state);
 +  }
@@ -295,14 +295,14 @@
 +
 +}  // namespace syncer
 --- /dev/null
-+++ b/components/sync/engine/extension_sync/extension_sync_connection_manager.h
++++ b/components/sync/engine/sync_vault/sync_vault_connection_manager.h
 @@ -0,0 +1,65 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
 +
-+#ifndef COMPONENTS_SYNC_ENGINE_EXTENSION_SYNC_EXTENSION_SYNC_CONNECTION_MANAGER_H_
-+#define COMPONENTS_SYNC_ENGINE_EXTENSION_SYNC_EXTENSION_SYNC_CONNECTION_MANAGER_H_
++#ifndef COMPONENTS_SYNC_ENGINE_SYNC_VAULT_SYNC_VAULT_CONNECTION_MANAGER_H_
++#define COMPONENTS_SYNC_ENGINE_SYNC_VAULT_SYNC_VAULT_CONNECTION_MANAGER_H_
 +
 +#include <cstdint>
 +#include <memory>
@@ -310,39 +310,39 @@
 +#include <string>
 +
 +#include "base/functional/callback.h"
-+#include "components/sync/engine/extension_sync/sync_vault_store.h"
++#include "components/sync/engine/sync_vault/sync_vault_store.h"
 +#include "components/sync/engine/net/server_connection_manager.h"
 +
 +namespace syncer {
 +
 +class LoopbackServer;
 +
-+struct ExtensionSyncStateDiagnostics {
++struct SyncVaultStateDiagnostics {
 +  uint64_t entity_count = 0;
 +  uint64_t state_bytes = 0;
 +
-+  bool operator==(const ExtensionSyncStateDiagnostics&) const = default;
++  bool operator==(const SyncVaultStateDiagnostics&) const = default;
 +};
 +
-+using ExtensionSyncDiagnosticsCallback =
++using SyncVaultDiagnosticsCallback =
 +    base::RepeatingCallback<void(std::optional<SyncVaultStoreError>,
 +                                 const SyncVaultCheckpoint&,
-+                                 std::optional<ExtensionSyncStateDiagnostics>)>;
++                                 std::optional<SyncVaultStateDiagnostics>)>;
 +
 +// Runs Chromium's LoopbackServer against the authenticated private-vault
 +// journal. Losing CAS writers reload the winning head and replay the command.
-+class ExtensionSyncConnectionManager : public ServerConnectionManager {
++class SyncVaultConnectionManager : public ServerConnectionManager {
 + public:
-+  explicit ExtensionSyncConnectionManager(
++  explicit SyncVaultConnectionManager(
 +      std::unique_ptr<SyncVaultStore> vault_store,
-+      ExtensionSyncDiagnosticsCallback diagnostics_callback = {});
++      SyncVaultDiagnosticsCallback diagnostics_callback = {});
 +
-+  ExtensionSyncConnectionManager(const ExtensionSyncConnectionManager&) =
++  SyncVaultConnectionManager(const SyncVaultConnectionManager&) =
 +      delete;
-+  ExtensionSyncConnectionManager& operator=(
-+      const ExtensionSyncConnectionManager&) = delete;
++  SyncVaultConnectionManager& operator=(
++      const SyncVaultConnectionManager&) = delete;
 +
-+  ~ExtensionSyncConnectionManager() override;
++  ~SyncVaultConnectionManager() override;
 +
 + private:
 +  HttpResponse PostBuffer(const std::string& buffer_in,
@@ -351,14 +351,14 @@
 +  HttpResponse ResponseForVaultError(SyncVaultStoreError error);
 +  void ReportDiagnostics(
 +      std::optional<SyncVaultStoreError> error,
-+      std::optional<ExtensionSyncStateDiagnostics> state = std::nullopt);
++      std::optional<SyncVaultStateDiagnostics> state = std::nullopt);
 +
 +  std::unique_ptr<SyncVaultStore> vault_store_;
 +  std::optional<SyncVaultState> loaded_state_;
 +  std::unique_ptr<LoopbackServer> loopback_server_;
-+  ExtensionSyncDiagnosticsCallback diagnostics_callback_;
++  SyncVaultDiagnosticsCallback diagnostics_callback_;
 +};
 +
 +}  // namespace syncer
 +
-+#endif  // COMPONENTS_SYNC_ENGINE_EXTENSION_SYNC_EXTENSION_SYNC_CONNECTION_MANAGER_H_
++#endif  // COMPONENTS_SYNC_ENGINE_SYNC_VAULT_SYNC_VAULT_CONNECTION_MANAGER_H_

--- a/patches/helium/core/sync/vault-format.patch
+++ b/patches/helium/core/sync/vault-format.patch
@@ -1,5 +1,5 @@
 --- /dev/null
-+++ b/components/sync/engine/extension_sync/BUILD.gn
++++ b/components/sync/engine/sync_vault/BUILD.gn
 @@ -0,0 +1,22 @@
 +# Copyright 2026 The Helium Authors
 +# You can use, redistribute, and/or modify this source code under
@@ -12,7 +12,7 @@
 +  extra_configs = [ "//build/config/compiler:wexit_time_destructors" ]
 +}
 +
-+source_set("extension_sync") {
++source_set("sync_vault") {
 +  sources = [
 +    "sync_vault_format.cc",
 +    "sync_vault_format.h",
@@ -24,7 +24,7 @@
 +  deps = [ ":sync_vault_proto" ]
 +}
 --- /dev/null
-+++ b/components/sync/engine/extension_sync/sync_vault.proto
++++ b/components/sync/engine/sync_vault/sync_vault.proto
 @@ -0,0 +1,51 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
@@ -78,13 +78,13 @@
 +  optional uint32 epoch = 5;
 +}
 --- /dev/null
-+++ b/components/sync/engine/extension_sync/sync_vault_format.cc
++++ b/components/sync/engine/sync_vault/sync_vault_format.cc
 @@ -0,0 +1,392 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
 +
-+#include "components/sync/engine/extension_sync/sync_vault_format.h"
++#include "components/sync/engine/sync_vault/sync_vault_format.h"
 +
 +#include <algorithm>
 +#include <cstdint>
@@ -97,7 +97,7 @@
 +#include "base/numerics/checked_math.h"
 +#include "base/numerics/safe_conversions.h"
 +#include "base/uuid.h"
-+#include "components/sync/engine/extension_sync/sync_vault.pb.h"
++#include "components/sync/engine/sync_vault/sync_vault.pb.h"
 +
 +namespace syncer {
 +
@@ -473,14 +473,14 @@
 +
 +}  // namespace syncer
 --- /dev/null
-+++ b/components/sync/engine/extension_sync/sync_vault_format.h
++++ b/components/sync/engine/sync_vault/sync_vault_format.h
 @@ -0,0 +1,145 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
 +
-+#ifndef COMPONENTS_SYNC_ENGINE_EXTENSION_SYNC_SYNC_VAULT_FORMAT_H_
-+#define COMPONENTS_SYNC_ENGINE_EXTENSION_SYNC_SYNC_VAULT_FORMAT_H_
++#ifndef COMPONENTS_SYNC_ENGINE_SYNC_VAULT_SYNC_VAULT_FORMAT_H_
++#define COMPONENTS_SYNC_ENGINE_SYNC_VAULT_SYNC_VAULT_FORMAT_H_
 +
 +#include <cstddef>
 +#include <cstdint>
@@ -489,7 +489,7 @@
 +
 +#include "base/containers/span.h"
 +#include "base/types/expected.h"
-+#include "components/sync/engine/extension_sync/sync_vault_limits.h"
++#include "components/sync/engine/sync_vault/sync_vault_limits.h"
 +
 +namespace syncer {
 +
@@ -619,16 +619,16 @@
 +
 +}  // namespace syncer
 +
-+#endif  // COMPONENTS_SYNC_ENGINE_EXTENSION_SYNC_SYNC_VAULT_FORMAT_H_
++#endif  // COMPONENTS_SYNC_ENGINE_SYNC_VAULT_SYNC_VAULT_FORMAT_H_
 --- /dev/null
-+++ b/components/sync/engine/extension_sync/sync_vault_limits.h
++++ b/components/sync/engine/sync_vault/sync_vault_limits.h
 @@ -0,0 +1,26 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
 +
-+#ifndef COMPONENTS_SYNC_ENGINE_EXTENSION_SYNC_SYNC_VAULT_LIMITS_H_
-+#define COMPONENTS_SYNC_ENGINE_EXTENSION_SYNC_SYNC_VAULT_LIMITS_H_
++#ifndef COMPONENTS_SYNC_ENGINE_SYNC_VAULT_SYNC_VAULT_LIMITS_H_
++#define COMPONENTS_SYNC_ENGINE_SYNC_VAULT_SYNC_VAULT_LIMITS_H_
 +
 +#include <cstddef>
 +
@@ -648,4 +648,4 @@
 +
 +}  // namespace syncer
 +
-+#endif  // COMPONENTS_SYNC_ENGINE_EXTENSION_SYNC_SYNC_VAULT_LIMITS_H_
++#endif  // COMPONENTS_SYNC_ENGINE_SYNC_VAULT_SYNC_VAULT_LIMITS_H_

--- a/patches/helium/core/sync/vault-store.patch
+++ b/patches/helium/core/sync/vault-store.patch
@@ -1,6 +1,6 @@
---- a/components/sync/engine/extension_sync/BUILD.gn
-+++ b/components/sync/engine/extension_sync/BUILD.gn
-@@ -16,6 +16,8 @@ source_set("extension_sync") {
+--- a/components/sync/engine/sync_vault/BUILD.gn
++++ b/components/sync/engine/sync_vault/BUILD.gn
+@@ -16,6 +16,8 @@ source_set("sync_vault") {
      "sync_vault_format.cc",
      "sync_vault_format.h",
      "sync_vault_limits.h",
@@ -10,13 +10,13 @@
    ]
  
 --- /dev/null
-+++ b/components/sync/engine/extension_sync/sync_vault_store.cc
++++ b/components/sync/engine/sync_vault/sync_vault_store.cc
 @@ -0,0 +1,901 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
 +
-+#include "components/sync/engine/extension_sync/sync_vault_store.h"
++#include "components/sync/engine/sync_vault/sync_vault_store.h"
 +
 +#include <algorithm>
 +#include <cstddef>
@@ -37,7 +37,7 @@
 +#include "base/strings/strcat.h"
 +#include "base/strings/string_number_conversions.h"
 +#include "base/time/time.h"
-+#include "components/sync/engine/extension_sync/sync_vault_cryptographer.h"
++#include "components/sync/engine/sync_vault/sync_vault_cryptographer.h"
 +#include "crypto/hash.h"
 +
 +namespace syncer {
@@ -914,14 +914,14 @@
 +
 +}  // namespace syncer
 --- /dev/null
-+++ b/components/sync/engine/extension_sync/sync_vault_store.h
++++ b/components/sync/engine/sync_vault/sync_vault_store.h
 @@ -0,0 +1,145 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
 +
-+#ifndef COMPONENTS_SYNC_ENGINE_EXTENSION_SYNC_SYNC_VAULT_STORE_H_
-+#define COMPONENTS_SYNC_ENGINE_EXTENSION_SYNC_SYNC_VAULT_STORE_H_
++#ifndef COMPONENTS_SYNC_ENGINE_SYNC_VAULT_SYNC_VAULT_STORE_H_
++#define COMPONENTS_SYNC_ENGINE_SYNC_VAULT_SYNC_VAULT_STORE_H_
 +
 +#include <cstddef>
 +#include <cstdint>
@@ -934,8 +934,8 @@
 +#include "base/functional/callback.h"
 +#include "base/sequence_checker.h"
 +#include "base/types/expected.h"
-+#include "components/sync/engine/extension_sync/sync_vault_format.h"
-+#include "components/sync/engine/extension_sync/sync_vault_transport.h"
++#include "components/sync/engine/sync_vault/sync_vault_format.h"
++#include "components/sync/engine/sync_vault/sync_vault_transport.h"
 +
 +namespace syncer {
 +
@@ -1060,4 +1060,4 @@
 +
 +}  // namespace syncer
 +
-+#endif  // COMPONENTS_SYNC_ENGINE_EXTENSION_SYNC_SYNC_VAULT_STORE_H_
++#endif  // COMPONENTS_SYNC_ENGINE_SYNC_VAULT_SYNC_VAULT_STORE_H_

--- a/patches/helium/core/sync/vault-transport.patch
+++ b/patches/helium/core/sync/vault-transport.patch
@@ -1,12 +1,12 @@
 --- /dev/null
-+++ b/components/sync/engine/extension_sync/sync_vault_transport.h
++++ b/components/sync/engine/sync_vault/sync_vault_transport.h
 @@ -0,0 +1,73 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
 +
-+#ifndef COMPONENTS_SYNC_ENGINE_EXTENSION_SYNC_SYNC_VAULT_TRANSPORT_H_
-+#define COMPONENTS_SYNC_ENGINE_EXTENSION_SYNC_SYNC_VAULT_TRANSPORT_H_
++#ifndef COMPONENTS_SYNC_ENGINE_SYNC_VAULT_SYNC_VAULT_TRANSPORT_H_
++#define COMPONENTS_SYNC_ENGINE_SYNC_VAULT_SYNC_VAULT_TRANSPORT_H_
 +
 +#include <cstddef>
 +#include <cstdint>
@@ -73,10 +73,10 @@
 +
 +}  // namespace syncer
 +
-+#endif  // COMPONENTS_SYNC_ENGINE_EXTENSION_SYNC_SYNC_VAULT_TRANSPORT_H_
---- a/components/sync/engine/extension_sync/BUILD.gn
-+++ b/components/sync/engine/extension_sync/BUILD.gn
-@@ -16,6 +16,7 @@ source_set("extension_sync") {
++#endif  // COMPONENTS_SYNC_ENGINE_SYNC_VAULT_SYNC_VAULT_TRANSPORT_H_
+--- a/components/sync/engine/sync_vault/BUILD.gn
++++ b/components/sync/engine/sync_vault/BUILD.gn
+@@ -16,6 +16,7 @@ source_set("sync_vault") {
      "sync_vault_format.cc",
      "sync_vault_format.h",
      "sync_vault_limits.h",


### PR DESCRIPTION
move the private vault engine out of extension_sync and rename its build target, backend, connection manager, and diagnostics accordingly

Related: #90