### PR TITLE
helium/settings: define private sync setup contract

### DIFF
--- a/patches/helium/settings/sync-setup-contract.patch
+++ b/patches/helium/settings/sync-setup-contract.patch
@@ -1,0 +1,162 @@
+--- a/chrome/browser/ui/webui/settings/BUILD.gn
++++ b/chrome/browser/ui/webui/settings/BUILD.gn
+@@ -10,7 +10,10 @@ import("//mojo/public/tools/bindings/moj
+ assert(is_win || is_mac || is_linux || is_chromeos)
+ 
+ mojom("mojo_bindings") {
+-  sources = [ "browser_shortcuts.mojom" ]
++  sources = [
++    "browser_shortcuts.mojom",
++    "extension_sync.mojom",
++  ]
+   webui_module_path = "/"
+ }
+ 
+--- /dev/null
++++ b/chrome/browser/ui/webui/settings/extension_sync.mojom
+@@ -0,0 +1,145 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++module settings.mojom;
++
++enum ExtensionSyncErrorCode {
++  kOperationInProgress,
++  kInvalidArgument,
++  kInvalidSetupState,
++  kProviderUnavailable,
++  kAuthenticationRequired,
++  kNotFound,
++  kConflict,
++  kNetworkError,
++  kTemporaryError,
++  kQuotaExceeded,
++  kAccessDenied,
++  kInvalidData,
++  kIntegrityError,
++  kUnsupported,
++  kAborted,
++  kConfigurationChanged,
++  kRestartRequired,
++  kLocalBackendEnabled,
++  kLocalKeyStorageFailed,
++};
++
++struct ExtensionSyncError {
++  ExtensionSyncErrorCode code;
++  // Optional localized detail supplied by the selected provider. Browser
++  // errors are rendered from `code` using Settings string resources.
++  string? provider_message;
++};
++
++struct ExtensionSyncAccountKeyProvider {
++  // Provider-supplied explanation shown verbatim in the consent dialog.
++  string reason;
++};
++
++struct ExtensionSyncProvider {
++  string id;
++  string name;
++  ExtensionSyncAccountKeyProvider? account_key_provider;
++};
++
++struct ExtensionSyncVault {
++  string display_name;
++  string vault_uuid;
++};
++
++enum ExtensionSyncProviderState {
++  kUnknown,
++  kReady,
++  kAuthenticationRequired,
++  kOffline,
++  kQuotaExceeded,
++};
++
++struct ExtensionSyncHealth {
++  ExtensionSyncProviderState provider_state;
++  bool blocking_error;
++  bool initial_sync_complete;
++  bool reconciliation_failed;
++};
++
++enum ExtensionSyncProviderConfigurationState {
++  kNone,
++  kConfiguring,
++  kPendingUserAction,
++  kReady,
++};
++
++struct ExtensionSyncStatus {
++  bool configured;
++  bool active;
++  bool restart_required;
++  string provider_id;
++  string vault_uuid;
++  ExtensionSyncProviderConfigurationState provider_configuration_state;
++  ExtensionSyncHealth? health;
++  array<ExtensionSyncProvider> providers;
++};
++
++struct ExtensionSyncProviderSelection {
++  ExtensionSyncProvider provider;
++  array<ExtensionSyncVault> vaults;
++  string suggested_vault_name;
++};
++
++enum ExtensionSyncSetupAction {
++  // The provider will receive and wrap a newly generated vault key only after
++  // the user accepts its declared name and reason.
++  kConfirmProviderKeyProtection,
++  // The provider will unwrap and return an existing vault key only after the
++  // user accepts its declared name and reason.
++  kConfirmProviderKeyRecovery,
++  // The browser generated a recovery key that the user must save.
++  kSaveRecoveryKey,
++  // An existing vault requires its recovery key.
++  kEnterRecoveryKey,
++  // Local key protection and persistent configuration are complete.
++  kConfigured,
++};
++
++struct ExtensionSyncSetupResponse {
++  ExtensionSyncSetupAction action;
++  string vault_uuid;
++  string? recovery_key;
++  ExtensionSyncAccountKeyProvider? account_key_provider;
++};
++
++interface ExtensionSyncPage {
++  StatusChanged(ExtensionSyncStatus status);
++  SetupAborted(ExtensionSyncError error);
++};
++
++interface ExtensionSyncHandler {
++  GetStatus() => (ExtensionSyncStatus status);
++  SelectProvider(string provider_id) =>
++      (ExtensionSyncProviderSelection? selection, ExtensionSyncError? error);
++  CreateVault(string display_name) =>
++      (ExtensionSyncSetupResponse? response, ExtensionSyncError? error);
++  RenameVault(string vault_uuid, string display_name) =>
++      (ExtensionSyncError? error);
++  ConnectVault(string vault_uuid) =>
++      (ExtensionSyncSetupResponse? response, ExtensionSyncError? error);
++  ConfirmProviderKeyAccess() =>
++      (ExtensionSyncSetupResponse? response, ExtensionSyncError? error);
++  DeclineProviderKeyAccess() =>
++      (ExtensionSyncSetupResponse? response, ExtensionSyncError? error);
++  ConfirmRecoveryKeySaved() =>
++      (ExtensionSyncSetupResponse? response, ExtensionSyncError? error);
++  CompleteRecoveryKeySetup(string recovery_key) =>
++      (ExtensionSyncSetupResponse? response, ExtensionSyncError? error);
++  CancelSetup() => (ExtensionSyncError? error);
++  Retry() => (ExtensionSyncError? error);
++  Disconnect() => (ExtensionSyncError? error);
++};
++
++interface ExtensionSyncHandlerFactory {
++  CreateExtensionSyncHandler(
++      pending_remote<ExtensionSyncPage> page,
++      pending_receiver<ExtensionSyncHandler> handler);
++};

--- a/patches/series
+++ b/patches/series
@@ -248,6 +248,7 @@ helium/settings/clear-browsing-data-popup.patch
 helium/settings/crash-reporting-settings.patch
 helium/settings/helium-noise-settings.patch
 helium/settings/network-and-security-page.patch
+helium/settings/sync-setup-contract.patch
 
 helium/hop/setup.patch
 helium/hop/disable-password-manager.patch


### PR DESCRIPTION
define the mojo types and interfaces used by settings ui to select a provider, create or connect to a vault, complete key setup, and report the resulting setup status and health

Related: #90