### PR TITLE
helium/core/sync/provider: drop consent fingerprints

### DIFF
--- a/patches/helium/core/sync/provider/profile-prefs.patch
+++ b/patches/helium/core/sync/provider/profile-prefs.patch
@@ -20,7 +20,7 @@
    extensions::AudioAPI::RegisterUserPrefs(registry);
 --- /dev/null
 +++ b/chrome/browser/sync/private_sync/private_sync_prefs.cc
-@@ -0,0 +1,266 @@
+@@ -0,0 +1,259 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
@@ -49,7 +49,6 @@
 +constexpr char kVaultUuidField[] = "vault_uuid";
 +constexpr char kEncryptedVaultKeyField[] = "encrypted_vault_key";
 +constexpr char kKeyModeField[] = "key_mode";
-+constexpr char kConsentFingerprintField[] = "consent_fingerprint";
 +constexpr char kEncryptedCheckpointField[] = "encrypted_checkpoint";
 +constexpr char kRecoveryKeyMode[] = "recovery_key";
 +constexpr char kAccountBoundEnvelopeMode[] = "account_bound_envelope";
@@ -84,12 +83,9 @@
 +  const std::string* vault_uuid = value.FindString(kVaultUuidField);
 +  const std::string* encrypted_key = value.FindString(kEncryptedVaultKeyField);
 +  const std::string* key_mode = value.FindString(kKeyModeField);
-+  const std::string* consent_fingerprint =
-+      value.FindString(kConsentFingerprintField);
 +  if (value.FindInt(kSchemaVersionField) != kCurrentSchemaVersion ||
 +      !provider_kind || !provider_id || provider_id->empty() || !vault_uuid ||
-+      !key_mode || !encrypted_key || !consent_fingerprint ||
-+      consent_fingerprint->empty() ||
++      !key_mode || !encrypted_key ||
 +      !base::Uuid::ParseLowercase(*vault_uuid).is_valid()) {
 +    return std::nullopt;
 +  }
@@ -115,8 +111,6 @@
 +  } else {
 +    return std::nullopt;
 +  }
-+  configuration.consent_fingerprint = *consent_fingerprint;
-+
 +  if (const std::string* encrypted_checkpoint =
 +          value.FindString(kEncryptedCheckpointField)) {
 +    std::optional<std::vector<uint8_t>> protected_checkpoint =
@@ -142,8 +136,7 @@
 +          .Set(kKeyModeField,
 +               configuration.key_mode == KeyMode::kAccountBoundEnvelope
 +                   ? kAccountBoundEnvelopeMode
-+                   : kRecoveryKeyMode)
-+          .Set(kConsentFingerprintField, configuration.consent_fingerprint);
++                   : kRecoveryKeyMode);
 +  if (configuration.encrypted_checkpoint) {
 +    value.Set(kEncryptedCheckpointField,
 +              base::Base64Encode(*configuration.encrypted_checkpoint));
@@ -289,7 +282,7 @@
 +}  // namespace browser_sync::private_sync_prefs
 --- /dev/null
 +++ b/chrome/browser/sync/private_sync/private_sync_prefs.h
-@@ -0,0 +1,96 @@
+@@ -0,0 +1,95 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
@@ -325,7 +318,6 @@
 +  std::string vault_uuid;
 +  std::vector<uint8_t> encrypted_vault_key;
 +  KeyMode key_mode = KeyMode::kRecoveryKey;
-+  std::string consent_fingerprint;
 +  std::optional<std::vector<uint8_t>> encrypted_checkpoint;
 +
 +  bool operator==(const Configuration&) const = default;


### PR DESCRIPTION
keep provider reasons display-only so wording, translation, and locale changes cannot invalidate configured providers

Related: #90