### PR TITLE
helium/core: disable webotp renderer feature by default

### DIFF
--- a/patches/helium/core/disable-non-standard-auth-features.patch
+++ b/patches/helium/core/disable-non-standard-auth-features.patch
@@ -32,3 +32,16 @@
  
  // Trial to disable synchronous draw for synchronous compositor (ie Android
  // WebView).
+--- a/content/child/runtime_features.cc
++++ b/content/child/runtime_features.cc
+@@ -513,6 +513,10 @@ void SetCustomizedRuntimeFeaturesFromCom
+ // Ensures that the various ways of enabling/disabling features do not produce
+ // an invalid configuration.
+ void ResolveInvalidConfigurations() {
++  if (!base::FeatureList::IsEnabled(features::kWebOTP)) {
++    WebRuntimeFeatures::EnableWebOTP(false);
++  }
++
+   // Fenced frames cannot be enabled without the support of the
+   // browser process.
+   if ((base::FeatureList::IsEnabled(features::kPrivacySandboxAdsAPIsOverride) ||


### PR DESCRIPTION
fixes #2426