### PR TITLE
helium/ui/tab-icon: new coherent appearance and hibernated state

### DIFF
--- a/i18n/source.gen.json
+++ b/i18n/source.gen.json
@@ -937,6 +937,18 @@
     "message": "Helium defaults"
   },
   {
+    "name": "IDS_SETTINGS_HIBERNATED_APPEARANCE_LABEL",
+    "source": "chrome/app/settings_strings.grdp",
+    "context": "Label for a performance setting that controls whether hibernated tabs are visually differentiated.",
+    "message": "Differentiate hibernated tabs"
+  },
+  {
+    "name": "IDS_SETTINGS_HIBERNATED_APPEARANCE_DESCRIPTION",
+    "source": "chrome/app/settings_strings.grdp",
+    "context": "Description for a performance setting that controls whether hibernated tab icons are displayed in grayscale.",
+    "message": "Display hibernated tab icons in grayscale"
+  },
+  {
     "name": "IDS_ACCNAME_APP_MENU",
     "source": "chrome/app/generated_resources.grd",
     "context": "The accessible name for the app menu button.",

--- a/patches/helium/ui/layout/shortcuts.patch
+++ b/patches/helium/ui/layout/shortcuts.patch
@@ -176,7 +176,7 @@
      VK_NEXT,        IDC_MOVE_TAB_NEXT,          VIRTKEY, CONTROL, SHIFT
 --- a/chrome/app/settings_strings.grdp
 +++ b/chrome/app/settings_strings.grdp
-@@ -4828,6 +4828,16 @@
+@@ -4834,6 +4834,16 @@
        Enable quick page link copying with Ctrl+Shift+C
      </message>
    </if>

--- a/patches/helium/ui/tab-favicon-retention.patch
+++ b/patches/helium/ui/tab-favicon-retention.patch
@@ -1,0 +1,416 @@
+--- a/components/favicon/core/favicon_handler.cc
++++ b/components/favicon/core/favicon_handler.cc
+@@ -280,12 +280,14 @@ void FaviconHandler::SetFavicon(const GU
+   NotifyFaviconUpdated(icon_url, icon_type, image);
+ }
+ 
+-void FaviconHandler::MaybeDeleteFaviconMappings() {
++void FaviconHandler::FinishWithoutFavicon() {
+   DCHECK(candidates_received_);
+   DCHECK(got_favicon_from_history_);
++  DCHECK(final_candidates_);
++
++  current_candidate_index_ = final_candidates_->size();
++  best_favicon_ = DownloadedFavicon();
+ 
+-  // The order of these conditions is important because we want the feature
+-  // state to be checked at the very end.
+   if (!error_other_than_404_found_ &&
+       notification_icon_type_ != favicon_base::IconType::kInvalid) {
+     if (service_ && !delegate_->IsOffTheRecord()) {
+@@ -296,6 +298,14 @@ void FaviconHandler::MaybeDeleteFaviconM
+ 
+     notification_icon_url_ = GURL();
+     notification_icon_type_ = favicon_base::IconType::kInvalid;
++    return;
++  }
++
++  // Completion must also be reported for pages that had no cached favicon.
++  if (notification_icon_type_ == favicon_base::IconType::kInvalid) {
++    delegate_->OnFaviconUnavailable(
++        last_page_url_, handler_type_,
++        /*clear_saved_favicon=*/!error_other_than_404_found_);
+   }
+ }
+ 
+@@ -337,6 +347,13 @@ void FaviconHandler::OnUpdateCandidates(
+     return;
+   }
+ 
++  // Native pages can use browser-provided favicons without declaring icons.
++  // The driver passes a manifest URL only to handlers that support it.
++  if (candidates.empty() && manifest_url.is_empty() &&
++      !page_url.SchemeIsHTTPOrHTTPS()) {
++    return;
++  }
++
+   // `candidates or `manifest_url` could have been modified via Javascript. If
+   // neither changed, ignore the call.
+   if (candidates_received_ && manifest_url_ == manifest_url &&
+@@ -490,7 +507,7 @@ void FaviconHandler::OnGotInitialHistory
+   if (final_candidates_->empty()) {
+     // The page lists no candidates that match our target `icon_types_`, so
+     // check if any existing mappings should be deleted.
+-    MaybeDeleteFaviconMappings();
++    FinishWithoutFavicon();
+     return;
+   }
+ 
+@@ -529,7 +546,9 @@ void FaviconHandler::OnDidDownloadFavico
+       if (service_) {
+         service_->UnableToDownloadFavicon(image_url);
+       }
+-    } else if (http_status_code != 0) {
++    } else if (http_status_code != 0 || id != 0) {
++      // A real download can fail without an HTTP response (status 0).
++      // A zero `id` identifies a skipped, previously failed download.
+       // `http_status_code` might be HTTP_OK here, but this is still
+       // considered an error since `bitmaps` is empty.
+       error_other_than_404_found_ = true;
+@@ -566,7 +585,8 @@ void FaviconHandler::OnDidDownloadFavico
+   } else {
+     if (best_favicon_.candidate.icon_type == favicon_base::IconType::kInvalid) {
+       // No valid icon found, so check if mappings should be deleted.
+-      MaybeDeleteFaviconMappings();
++      FinishWithoutFavicon();
++      return;
+     } else {
+       // We have either found the ideal candidate or run out of candidates.
+       // No more icons to request, set the favicon from the candidate. The
+@@ -641,6 +661,11 @@ void FaviconHandler::OnFaviconDataForIni
+ 
+   if (final_candidates_) {
+     OnGotInitialHistoryDataAndIconURLCandidates();
++  } else if (notification_icon_type_ == favicon_base::IconType::kInvalid) {
++    // A stopped load may never send candidates. Reconsider retention now that
++    // the history lookup has finished.
++    delegate_->OnFaviconUnavailable(last_page_url_, handler_type_,
++                                    /*clear_saved_favicon=*/false);
+   }
+ }
+ 
+--- a/components/favicon/core/favicon_handler.h
++++ b/components/favicon/core/favicon_handler.h
+@@ -123,6 +123,14 @@ class FaviconHandler {
+     virtual void OnFaviconDeleted(
+         const GURL& page_url,
+         FaviconDriverObserver::NotificationIconType notification_icon_type) = 0;
++
++    // Notifies that history or candidate processing finished without a usable
++    // favicon. `clear_saved_favicon` is true only after candidate processing
++    // finishes without an error that would preserve an existing favicon.
++    virtual void OnFaviconUnavailable(
++        const GURL& page_url,
++        FaviconDriverObserver::NotificationIconType notification_icon_type,
++        bool clear_saved_favicon) {}
+   };
+ 
+   // `service` may be null (which means favicons are not saved). If `service`
+@@ -159,6 +167,19 @@ class FaviconHandler {
+   // data from the CoreFaviconService. Reserved for testing.
+   bool HasPendingTasksForTest();
+ 
++  // True after history and received candidates finish without a usable icon
++  // or a transient download error.
++  // A stopped load can finish without candidates if `waiting_for_candidates`
++  // is false; received candidates may still be waiting for a manifest.
++  bool IsFaviconKnownMissing(const GURL& page_url,
++                            bool waiting_for_candidates) const {
++    return page_url == last_page_url_ && got_favicon_from_history_ &&
++           notification_icon_type_ == favicon_base::IconType::kInvalid &&
++           (final_candidates_
++                ? !current_candidate() && !error_other_than_404_found_
++                : !candidates_received_ && !waiting_for_candidates);
++  }
++
+   // Get the maximal icon size in pixels for a handler of type `handler_type`.
+   // `candidates_from_web_manifest` represents whether the icons are coming
+   // from a Web Manifest.
+@@ -261,12 +282,10 @@ class FaviconHandler {
+                   const gfx::Image& image,
+                   favicon_base::IconType icon_type);
+ 
+-  // Deletes the favicon mappings for `page_urls_`, if:
+-  // - We're not in incognito.
+-  // - A mapping is known to exist (reflected by `notification_icon_type_`).
+-  // - All download attempts returned 404s OR no relevant candidate was
+-  //   provided (as per `icon_types_`).
+-  void MaybeDeleteFaviconMappings();
++  // Finishes candidate processing without a new favicon. Deletes known
++  // mappings outside incognito unless a download error requires keeping them.
++  // Updates the completion state before any delegate notification.
++  void FinishWithoutFavicon();
+ 
+   // Notifies `driver_` that FaviconHandler found an icon which matches the
+   // `handler_type_` criteria. NotifyFaviconUpdated() can be called multiple
+--- a/components/favicon/core/favicon_driver_impl.cc
++++ b/components/favicon/core/favicon_driver_impl.cc
+@@ -53,6 +53,17 @@ bool FaviconDriverImpl::HasPendingTasksF
+   return false;
+ }
+ 
++bool FaviconDriverImpl::FaviconIsKnownMissing(
++    const GURL& page_url,
++    bool waiting_for_candidates) const {
++  for (const auto& handler : handlers_) {
++    if (!handler->IsFaviconKnownMissing(page_url, waiting_for_candidates)) {
++      return false;
++    }
++  }
++  return true;
++}
++
+ void FaviconDriverImpl::SetFaviconOutOfDateForPage(const GURL& url,
+                                                    bool force_reload) {
+   if (favicon_service_) {
+--- a/components/favicon/core/favicon_driver_impl.h
++++ b/components/favicon/core/favicon_driver_impl.h
+@@ -44,6 +44,12 @@ class FaviconDriverImpl : public Favicon
+   explicit FaviconDriverImpl(CoreFaviconService* favicon_service);
+   ~FaviconDriverImpl() override;
+ 
++  // True when all handlers finished without a usable favicon. If
++  // `waiting_for_candidates` is false, only history needs to finish when no
++  // candidates have been received.
++  bool FaviconIsKnownMissing(const GURL& page_url,
++                            bool waiting_for_candidates) const;
++
+   // Informs CoreFaviconService that the favicon for `url` is out of date. If
+   // `force_reload` is true, then discard information about favicon download
+   // failures.
+--- a/third_party/blink/renderer/core/frame/local_frame.cc
++++ b/third_party/blink/renderer/core/frame/local_frame.cc
+@@ -3412,9 +3412,9 @@ void LocalFrame::UpdateFaviconURL(mojom:
+       1 << static_cast<int>(
+           mojom::blink::FaviconIconType::kTouchPrecomposedIcon);
+   Vector<IconURL> icon_urls = GetDocument()->IconURLs(icon_types_mask);
+-  if (icon_urls.empty())
+-    return;
+ 
++  // An empty list also completes favicon discovery, for example when CSP
++  // blocks the default favicon and the document declares no other icons.
+   Vector<mojom::blink::FaviconURLPtr> urls;
+   urls.reserve(icon_urls.size());
+   for (const auto& icon_url : icon_urls) {
+--- a/components/favicon/content/content_favicon_driver.cc
++++ b/components/favicon/content/content_favicon_driver.cc
+@@ -16,6 +16,7 @@
+ #include "content/public/browser/navigation_entry.h"
+ #include "content/public/browser/navigation_handle.h"
+ #include "content/public/browser/page.h"
++#include "content/public/browser/render_frame_host.h"
+ #include "third_party/blink/public/mojom/manifest/manifest.mojom.h"
+ #include "ui/gfx/image/image.h"
+ 
+@@ -48,6 +49,21 @@ GURL ContentFaviconDriver::GetActiveURL(
+   return entry ? entry->GetURL() : GURL();
+ }
+ 
++bool ContentFaviconDriver::ShouldWaitForFavicon() const {
++  if (FaviconIsValid()) {
++    return false;
++  }
++
++  auto* const rfh = web_contents()->GetPrimaryMainFrame();
++  // A stopped load may still receive history results. Normal completion sends
++  // candidates after the loading state changes, with downloads finishing later.
++  const bool waiting_for_candidates =
++      web_contents()->IsLoading() ||
++      rfh->IsDocumentOnLoadCompletedInMainFrame();
++  return !FaviconIsKnownMissing(rfh->GetLastCommittedURL(),
++                               waiting_for_candidates);
++}
++
+ GURL ContentFaviconDriver::GetManifestURL(content::RenderFrameHost* rfh) {
+   DocumentManifestData* document_data =
+       DocumentManifestData::GetOrCreateForCurrentDocument(rfh);
+@@ -163,6 +179,23 @@ void ContentFaviconDriver::OnFaviconDele
+                                 content::FaviconStatus().image);
+ }
+ 
++void ContentFaviconDriver::OnFaviconUnavailable(
++    const GURL& page_url,
++    FaviconDriverObserver::NotificationIconType notification_icon_type,
++    bool clear_saved_favicon) {
++  content::NavigationEntry* entry =
++      web_contents()->GetController().GetLastCommittedEntry();
++  if (notification_icon_type == FaviconDriverObserver::NON_TOUCH_16_DIP &&
++      entry && entry->GetURL() == page_url) {
++    // Reloads can preserve a valid entry favicon even when history has no copy.
++    if (clear_saved_favicon && entry->GetFavicon().valid) {
++      OnFaviconDeleted(page_url, notification_icon_type);
++      return;
++    }
++    web_contents()->NotifyNavigationStateChanged(content::INVALIDATE_TYPE_TAB);
++  }
++}
++
+ void ContentFaviconDriver::DidUpdateFaviconURL(
+     content::RenderFrameHost* rfh,
+     const std::vector<blink::mojom::FaviconURLPtr>& candidates,
+@@ -245,7 +278,10 @@ void ContentFaviconDriver::DidFinishNavi
+   DocumentManifestData* document_data =
+       DocumentManifestData::GetOrCreateForCurrentDocument(
+           navigation_handle->GetRenderFrameHost());
+-  document_data->has_manifest_url = navigation_data->has_manifest_url;
++  // A restored document already has its manifest data.
++  if (!navigation_handle->IsServedFromBackForwardCache()) {
++    document_data->has_manifest_url = navigation_data->has_manifest_url;
++  }
+ 
+   // Wait till the user navigates to a new URL to start checking the cache
+   // again. The cache may be ignored for non-reload navigations (e.g.
+@@ -260,6 +296,15 @@ void ContentFaviconDriver::DidFinishNavi
+ 
+   // Get the favicon, either from history or request it from the net.
+   FetchFavicon(url, navigation_handle->IsSameDocument());
++
++  // A loaded document restored from BFCache does not send another favicon
++  // update. Reuse its candidates, including an empty list, to finish the lookup.
++  auto* const rfh = navigation_handle->GetRenderFrameHost();
++  if (navigation_handle->IsServedFromBackForwardCache() &&
++      rfh->IsDocumentOnLoadCompletedInMainFrame()) {
++    OnUpdateCandidates(url, FaviconURLsFromContentFaviconURLs(rfh->FaviconURLs()),
++                       GetManifestURL(rfh));
++  }
+ }
+ 
+ NAVIGATION_HANDLE_USER_DATA_KEY_IMPL(
+--- a/components/favicon/content/content_favicon_driver.h
++++ b/components/favicon/content/content_favicon_driver.h
+@@ -39,6 +39,9 @@ class ContentFaviconDriver
+   bool FaviconIsValid() const override;
+   GURL GetActiveURL() override;
+ 
++  // Whether to wait for this page's favicon before showing a fallback.
++  bool ShouldWaitForFavicon() const;
++
+   GURL GetManifestURL(content::RenderFrameHost* rfh);
+ 
+  protected:
+@@ -88,6 +91,10 @@ class ContentFaviconDriver
+   void OnFaviconDeleted(const GURL& page_url,
+                         FaviconDriverObserver::NotificationIconType
+                             notification_icon_type) override;
++  void OnFaviconUnavailable(
++      const GURL& page_url,
++      FaviconDriverObserver::NotificationIconType notification_icon_type,
++      bool clear_saved_favicon) override;
+ 
+   // content::WebContentsObserver implementation.
+   void DidUpdateFaviconURL(
+--- a/chrome/browser/ui/tab_ui_helper.cc
++++ b/chrome/browser/ui/tab_ui_helper.cc
+@@ -25,11 +25,13 @@
+ #include "chrome/browser/ui/web_applications/app_browser_controller.h"
+ #include "chrome/common/webui_url_constants.h"
+ #include "chrome/grit/generated_resources.h"
++#include "components/favicon/content/content_favicon_driver.h"
+ #include "components/security_interstitials/content/security_interstitial_tab_helper.h"
+ #include "components/tabs/public/tab_interface.h"
+ #include "components/tabs/public/tab_network_state.h"
+ #include "content/public/browser/navigation_controller.h"
+ #include "content/public/browser/navigation_entry.h"
++#include "content/public/browser/render_frame_host.h"
+ #include "content/public/browser/web_contents.h"
+ #include "content/public/common/url_constants.h"
+ #include "ui/base/l10n/l10n_util.h"
+@@ -188,6 +190,7 @@ ui::ImageModel TabUIHelper::GetFavicon()
+   if (wc_listener) {
+     if (const std::optional<tab_groups::DeferredTabState>& deferred_tab_state =
+             wc_listener->deferred_tab_state()) {
++      retained_favicon_ = gfx::Image();
+       return deferred_tab_state.value().favicon();
+     }
+   }
+@@ -199,19 +202,58 @@ ui::ImageModel TabUIHelper::GetFavicon()
+     const gfx::ImageSkia home_tab_icon =
+         web_app_browser_controller->GetHomeTabIcon();
+     if (!home_tab_icon.isNull()) {
++      retained_favicon_ = gfx::Image();
+       return ui::ImageModel::FromImageSkia(home_tab_icon);
+     } else {
+       gfx::ImageSkia fallback_home_icon =
+           web_app_browser_controller->GetFallbackHomeTabIcon();
+       if (!fallback_home_icon.isNull()) {
++        retained_favicon_ = gfx::Image();
+         return ui::ImageModel::FromImageSkia(fallback_home_icon);
+       }
+     }
+   }
+ #endif  // !BUILDFLAG(IS_ANDROID)
+ 
+-  return ui::ImageModel::FromImage(
+-      favicon::TabFaviconFromWebContents(web_contents()));
++  content::WebContents* const contents = web_contents();
++  gfx::Image favicon = favicon::TabFaviconFromWebContents(contents);
++  auto* const rfh = contents->GetPrimaryMainFrame();
++  const auto* entry = contents->GetController().GetLastCommittedEntry();
++  // Discard preserves the navigation entry but replaces the live document.
++  // Use the entry until a document commits, including after WasDiscarded()
++  // resets at the start of the restoration navigation.
++  const bool use_saved_entry = entry && rfh->GetLastCommittedURL().is_empty();
++  const GURL& page_url =
++      use_saved_entry ? entry->GetURL() : rfh->GetLastCommittedURL();
++  const url::Origin page_origin =
++      use_saved_entry ? url::Origin::Create(page_url)
++                      : rfh->GetLastCommittedOrigin();
++  const auto* driver =
++      favicon::ContentFaviconDriver::FromWebContents(contents);
++  if (!driver || !page_url.SchemeIsHTTPOrHTTPS() || rfh->IsErrorDocument() ||
++      (use_saved_entry && entry->GetPageType() == content::PAGE_TYPE_ERROR)) {
++    retained_favicon_ = gfx::Image();
++    return ui::ImageModel::FromImage(favicon);
++  }
++
++  if (driver->FaviconIsValid()) {
++    // A saved URL cannot recover an opaque document's origin.
++    if (!use_saved_entry) {
++      retained_favicon_origin_ = page_origin;
++    }
++    retained_favicon_ = retained_favicon_origin_.IsSameOriginWith(page_origin)
++                            ? favicon
++                            : gfx::Image();
++    return ui::ImageModel::FromImage(favicon);
++  }
++
++  if (!retained_favicon_origin_.IsSameOriginWith(page_origin) ||
++      (!use_saved_entry && !driver->ShouldWaitForFavicon())) {
++    retained_favicon_ = gfx::Image();
++  }
++  return ui::ImageModel::FromImage(retained_favicon_.IsEmpty()
++                                      ? favicon
++                                      : retained_favicon_);
+ }
+ 
+ bool TabUIHelper::ShouldHideThrobber() const {
+--- a/chrome/browser/ui/tab_ui_helper.h
++++ b/chrome/browser/ui/tab_ui_helper.h
+@@ -17,6 +17,8 @@
+ #include "components/tabs/public/tab_network_state.h"
+ #include "content/public/browser/web_contents_observer.h"
+ #include "ui/base/unowned_user_data/scoped_unowned_user_data.h"
++#include "ui/gfx/image/image.h"
++#include "url/origin.h"
+ 
+ #if !BUILDFLAG(IS_ANDROID)
+ class Browser;
+@@ -67,6 +69,7 @@ class TabUIHelper : public tabs::Content
+ 
+   // Get the favicon of the tab. It will return a favicon from history service
+   // if it needs to, otherwise, it will return the favicon of the WebContents.
++  // Retains the previous same-origin favicon while a replacement is pending.
+   ui::ImageModel GetFavicon();
+ 
+   // Return true if the throbber should be hidden during a page load.
+@@ -131,6 +134,10 @@ class TabUIHelper : public tabs::Content
+   bool needs_attention_ = false;
+   base::CallbackListSubscription pin_tab_subscription_;
+ 
++  // Keep retention with the tab so it survives view recreation and discards.
++  gfx::Image retained_favicon_;
++  url::Origin retained_favicon_origin_;
++
+   base::RepeatingClosureList tab_ui_change_callbacks_;
+ 
+   ui::ScopedUnownedUserData<TabUIHelper> scoped_unowned_user_data_;

--- a/patches/helium/ui/tab-icon.patch
+++ b/patches/helium/ui/tab-icon.patch
@@ -1,0 +1,280 @@
+--- a/chrome/browser/ui/views/tabs/tab/tab_icon.cc
++++ b/chrome/browser/ui/views/tabs/tab/tab_icon.cc
+@@ -11,6 +11,7 @@
+ #include "base/time/default_tick_clock.h"
+ #include "base/time/time.h"
+ #include "base/trace_event/trace_event.h"
++#include "cc/paint/color_filter.h"
+ #include "chrome/browser/browser_process.h"
+ #include "chrome/browser/favicon/favicon_utils.h"
+ #include "chrome/browser/ui/browser_element_identifiers.h"
+@@ -27,6 +28,7 @@
+ #include "components/grit/components_scaled_resources.h"
+ #include "components/performance_manager/public/user_tuning/prefs.h"
+ #include "components/prefs/pref_service.h"
++#include "third_party/skia/include/effects/SkColorMatrix.h"
+ #include "ui/base/metadata/metadata_impl_macros.h"
+ #include "ui/base/resource/resource_bundle.h"
+ #include "ui/base/theme_provider.h"
+@@ -57,11 +59,11 @@
+ namespace {
+ 
+ constexpr int kAttentionIndicatorRadius = 3;
++constexpr float kDiscardedFaviconOpacity = 0.5f;
+ constexpr int kLoadingAnimationStrokeWidthDp = 2;
+ 
+-bool NetworkStateIsAnimated(tabs::TabNetworkState network_state) {
+-  return network_state != tabs::TabNetworkState::kNone &&
+-         network_state != tabs::TabNetworkState::kError;
++bool NetworkStateIsAnimated(tabs::TabNetworkState) {
++  return false;
+ }
+ 
+ // Helper class that manages the compositor-driven throbber animation.
+@@ -236,12 +238,7 @@ void TabIcon::StepLoadingAnimation(const
+   }
+ }
+ 
+-void TabIcon::ResizeDiscardIndicatorRadiusForWidth(int width) {
+-  increased_discard_indicator_radius_ =
+-      width >= gfx::kFaviconSize + 2 * kIncreasedDiscardIndicatorRadiusDp
+-          ? kIncreasedDiscardIndicatorRadiusDp
+-          : 0;
+-}
++void TabIcon::ResizeDiscardIndicatorRadiusForWidth(int) {}
+ 
+ void TabIcon::OnDiscardRingTreatmentEnabledChanged() {
+   discard_ring_treatment_enabled_ =
+@@ -254,13 +251,8 @@ void TabIcon::OnDiscardRingTreatmentEnab
+     was_discard_indicator_shown_ = show_discard_indicator;
+ 
+     // Directly set animations to their end states and do not animate.
+-    if (show_discard_indicator) {
+-      tab_discard_animation_.SetCurrentValue(1);
+-      favicon_size_animation_.Reset(0);
+-    } else {
+-      tab_discard_animation_.SetCurrentValue(0);
+-      favicon_size_animation_.Reset(1);
+-    }
++    tab_discard_animation_.Reset(show_discard_indicator ? 1.0 : 0.0);
++    UpdateThrobber();
+     SchedulePaint();
+   }
+ }
+@@ -284,8 +276,9 @@ void TabIcon::OnPaint(gfx::Canvas* canva
+   if (!GetShowingLoadingAnimation() && GetShowingAttentionIndicator() &&
+       !should_display_crashed_favicon_) {
+     PaintAttentionIndicatorAndIcon(canvas, GetIconToPaint(), icon_bounds);
+-  } else if (was_discard_indicator_shown_) {
+-    PaintDiscardRingAndIcon(canvas, GetIconToPaint(), icon_bounds);
++  } else if (was_discard_indicator_shown_ ||
++             tab_discard_animation_.is_animating()) {
++    PaintDiscardedFavicon(canvas, GetIconToPaint(), icon_bounds);
+   } else {
+     MaybePaintFavicon(canvas, GetIconToPaint(), icon_bounds);
+   }
+@@ -323,7 +316,6 @@ void TabIcon::OnThemeChanged() {
+ }
+ 
+ void TabIcon::AnimationProgressed(const gfx::Animation* animation) {
+-  UpdateThrobber();
+   SchedulePaint();
+ }
+ 
+@@ -366,30 +358,39 @@ void TabIcon::PaintAttentionIndicatorAnd
+   canvas->DrawCircle(circle_center, kAttentionIndicatorRadius, indicator_flags);
+ }
+ 
+-void TabIcon::PaintDiscardRingAndIcon(gfx::Canvas* canvas,
+-                                      const gfx::ImageSkia& icon,
+-                                      const gfx::Rect& icon_bounds) {
+-  // Fades in the discard ring and smaller favicon
+-  MaybePaintFavicon(canvas, icon, icon_bounds);
+-
+-  // Increase the bounds of the discard ring beyond the icon bounds if there is
+-  // enough space in the tab. This is safe because in the constructor, we have
+-  // already added insets so that the larger discard ring can expand into them
+-  // and won't be clipped, and the icon bounds will be inside those insets.
+-  gfx::Rect discard_ring_bounds = icon_bounds;
+-  discard_ring_bounds.Outset(increased_discard_indicator_radius_);
+-
+-  const ui::ColorProvider* color_provider = GetColorProvider();
+-  const views::Widget* widget = GetWidget();
+-  SkColor ring_color =
+-      color_provider->GetColor(widget && widget->ShouldPaintAsActive()
+-                                   ? kColorTabDiscardRingFrameActive
+-                                   : kColorTabDiscardRingFrameInactive);
+-
+-  // Painting Discard Ring
+-  PaintRingDottedPath(
+-      canvas, discard_ring_bounds, ring_color,
+-      /*opacity_ratio=*/tab_discard_animation_.GetCurrentValue());
++void TabIcon::PaintDiscardedFavicon(gfx::Canvas* canvas,
++                                    const gfx::ImageSkia& icon,
++                                    const gfx::Rect& bounds) {
++  TRACE_EVENT0("views", "TabIcon::PaintDiscardedFavicon");
++
++  if (icon.isNull()) {
++    return;
++  }
++
++  const double discard_fraction = tab_discard_animation_.GetCurrentValue();
++
++  // Fade the favicon to a partially transparent grayscale version while the
++  // tab is discarded. Opacity and saturation follow the same animation.
++  cc::PaintFlags flags;
++  flags.setAlphaf(gfx::Tween::FloatValueBetween(
++      discard_fraction, 1.0f, kDiscardedFaviconOpacity));
++
++  SkColorMatrix color_matrix;
++  color_matrix.setSaturation(
++      gfx::Tween::FloatValueBetween(discard_fraction, 1.0f, 0.0f));
++  // 4x5 matrix expected by cc::ColorFilter
++  float matrix_data[20];
++  color_matrix.getRowMajor(matrix_data);
++  flags.setColorFilter(cc::ColorFilter::MakeMatrix(matrix_data));
++
++  canvas->DrawImageInt(icon, 0, 0, bounds.width(), bounds.height(), bounds.x(),
++                       bounds.y(), bounds.width(), bounds.height(),
++                       /*filter=*/true, flags);
++
++  if (discard_fraction == 1.0) {
++    views::ElementTrackerViews::GetInstance()->NotifyCustomEvent(
++        kDiscardAnimationFinishes, this);
++  }
+ }
+ 
+ void TabIcon::PaintLoadingAnimation(gfx::Canvas* canvas, gfx::Rect bounds) {
+@@ -445,8 +446,7 @@ void TabIcon::MaybePaintFavicon(gfx::Can
+ 
+   std::unique_ptr<gfx::ScopedCanvas> scoped_canvas;
+ 
+-  if (GetShowingLoadingAnimation() || favicon_size_animation_.is_animating() ||
+-      was_discard_indicator_shown_) {
++  if ((false)) {
+     scoped_canvas = std::make_unique<gfx::ScopedCanvas>(canvas);
+     // The favicon is initially inset with the width of the loading-animation
+     // stroke + an additional dp to create some visual separation.
+@@ -491,14 +491,6 @@ void TabIcon::MaybePaintFavicon(gfx::Can
+   canvas->DrawImageInt(icon, 0, 0, bounds.width(), bounds.height(), bounds.x(),
+                        bounds.y(), bounds.width(), bounds.height(),
+                        /*filter=*/true);
+-
+-  // Emits a custom event when the favicon finishes shrinking and the discard
+-  // ring gets painted
+-  if (favicon_size_animation_.GetCurrentValue() == 0.0 &&
+-      tab_discard_animation_.GetCurrentValue() == 1.0) {
+-    views::ElementTrackerViews::GetInstance()->NotifyCustomEvent(
+-        kDiscardAnimationFinishes, this);
+-  }
+ }
+ 
+ bool TabIcon::GetNonDefaultFavicon() const {
+@@ -525,31 +517,12 @@ void TabIcon::SetDiscarded(bool discarde
+       is_discarded_ && discard_ring_treatment_enabled_;
+   if (was_discard_indicator_shown_ != show_discard_indicator) {
+     was_discard_indicator_shown_ = show_discard_indicator;
+-    favicon_size_animation_.SetSlideDuration(
++    tab_discard_animation_.SetSlideDuration(
+         gfx::Animation::RichAnimationDuration(base::Milliseconds(250)));
+     if (show_discard_indicator) {
+-      tab_discard_animation_.SetDuration(
+-          gfx::Animation::RichAnimationDuration(base::Seconds(1)));
+-      tab_discard_animation_.Start();
+-      favicon_size_animation_.Hide();
+-
+-      // Potentially show an IPH if a tab was discarded.
+-      const ui::ElementContext context =
+-          views::ElementTrackerViews::GetInstance()->GetContextForView(this);
+-      BrowserWindowInterface* browser = nullptr;
+-      ForEachCurrentBrowserWindowInterfaceOrderedByActivation(
+-          [&](BrowserWindowInterface* current_browser) {
+-            if (BrowserElements::From(current_browser)->GetContext() ==
+-                context) {
+-              browser = current_browser;
+-            }
+-            return !browser;
+-          });
+-      BrowserUserEducationInterface::From(browser)->MaybeShowFeaturePromo(
+-          feature_engagement::kIPHDiscardRingFeature);
++      tab_discard_animation_.Show();
+     } else {
+-      tab_discard_animation_.Stop();
+-      favicon_size_animation_.Show();
++      tab_discard_animation_.Hide();
+     }
+   }
+ }
+@@ -605,6 +578,10 @@ bool TabIcon::GetCrashed() const {
+ }
+ 
+ void TabIcon::UpdateThrobber() {
++  if (!tab_discard_animation_.is_animating() && !layer()) {
++    return;
++  }
++
+   TRACE_EVENT0("ui", "TabIcon::UpdateThrobber");
+   base::ScopedUmaHistogramTimer timer(
+       "Tab.Icon.UpdateThrobber.Time",
+--- a/chrome/browser/ui/views/tabs/tab/tab_icon.h
++++ b/chrome/browser/ui/views/tabs/tab/tab_icon.h
+@@ -117,10 +117,11 @@ class TabIcon : public views::View, publ
+                                       const gfx::ImageSkia& icon,
+                                       const gfx::Rect& bounds);
+ 
+-  // Paints a dimmed and shrunken favicon surrounded by the discard ring
+-  void PaintDiscardRingAndIcon(gfx::Canvas* canvas,
+-                               const gfx::ImageSkia& icon,
+-                               const gfx::Rect& bounds);
++  // Paints the favicon with grayscale and opacity reflecting the discard
++  // animation.
++  void PaintDiscardedFavicon(gfx::Canvas* canvas,
++                             const gfx::ImageSkia& icon,
++                             const gfx::Rect& bounds);
+ 
+   // Paint either the indeterimate throbber or progress indicator according to
+   // current tab state.
+@@ -204,7 +205,7 @@ class TabIcon : public views::View, publ
+ 
+   // Animation used when a tab is discarded so the favicon will partially
+   // fade out
+-  gfx::LinearAnimation tab_discard_animation_;
++  gfx::SlideAnimation tab_discard_animation_;
+ 
+   // The discard indicator will be shown only if the tab is discarded and the
+   // discard ring treatment pref is enabled. Keep track of both of the component
+--- a/chrome/app/settings_strings.grdp
++++ b/chrome/app/settings_strings.grdp
+@@ -1171,6 +1171,12 @@
+     <message name="IDS_SETTINGS_PERFORMANCE_DISCARD_RING_TREATMENT_ENABLED_DESCRIPTION_WITH_LEARN_LINK" desc="Label for a performance settings toggle description that controls whether the inactive tab UI is shown. Also contains a link to the help center article.">
+       A dotted circle appears around site icons.
+     </message>
++    <message name="IDS_SETTINGS_HIBERNATED_APPEARANCE_LABEL" desc="Label for a performance setting that controls whether hibernated tabs are visually differentiated.">
++      Differentiate hibernated tabs
++    </message>
++    <message name="IDS_SETTINGS_HIBERNATED_APPEARANCE_DESCRIPTION" desc="Description for a performance setting that controls whether hibernated tab icons are displayed in grayscale.">
++      Display hibernated tab icons in grayscale
++    </message>
+     <message name="IDS_SETTINGS_PERFORMANCE_TAB_HOVER_PREVIEW_CARD_LINK_TITLE" desc="Title for the link row that points to tab hover preview card apperance settings.">
+       Tab hover preview card appearance
+     </message>
+--- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
++++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
+@@ -1297,7 +1297,7 @@ void AddPerformanceStrings(content::WebU
+       {"tabDiscardingExceptionsActiveSiteAriaDescription",
+        IDS_SETTINGS_PERFORMANCE_TAB_DISCARDING_EXCEPTIONS_ACTIVE_SITE_ARIA_DESCRIPTION},
+       {"discardRingTreatmentEnabledLabel",
+-       IDS_SETTINGS_PERFORMANCE_DISCARD_RING_TREATMENT_ENABLED_LABEL},
++       IDS_SETTINGS_HIBERNATED_APPEARANCE_LABEL},
+       {"tabHoverPreviewCardLinkTitle",
+        IDS_SETTINGS_PERFORMANCE_TAB_HOVER_PREVIEW_CARD_LINK_TITLE},
+       {"tabHoverPreviewCardLinkSubtitle",
+@@ -1320,7 +1320,7 @@ void AddPerformanceStrings(content::WebU
+       {"batterySaverModeDescription",
+        IDS_SETTINGS_PERFORMANCE_BATTERY_SAVER_MODE_SETTING_DESCRIPTION},
+       {"discardRingTreatmentEnabledDescriptionWithLearnLink",
+-       IDS_SETTINGS_PERFORMANCE_DISCARD_RING_TREATMENT_ENABLED_DESCRIPTION_WITH_LEARN_LINK},
++       IDS_SETTINGS_HIBERNATED_APPEARANCE_DESCRIPTION},
+       {"memorySaverModeDescription",
+        IDS_SETTINGS_PERFORMANCE_MEMORY_SAVER_MODE_SETTING_DESCRIPTION},
+       {"performanceInterventionEnabledDescription",

--- a/patches/series
+++ b/patches/series
@@ -265,6 +265,8 @@ helium/ui/remove-toolbar-corners.patch
 helium/ui/location-bar.patch
 helium/ui/location-bar-page-action.patch
 helium/ui/tabs.patch
+helium/ui/tab-icon.patch
+helium/ui/tab-favicon-retention.patch
 helium/ui/tab-strip-controls.patch
 helium/ui/toolbar.patch
 helium/ui/remove-toolbar-dividers.patch


### PR DESCRIPTION
- removed loading indicators and choppy favicon scaling animations
- converted the discarded state from a ring to a smooth 50% transparent grayscale icon filter
- made the current favicon stay during same-origin navigation until the replacement favicon is valid, to prevent default site icon flicker

(prerequisite for progress bar and persistent pinned tabs)

hibernation (discard):

https://github.com/user-attachments/assets/d6974127-70d6-4eac-8f8e-fc238d29c1f9


consistent favicon without default icon flickering in between same-origin navigation:

https://github.com/user-attachments/assets/9d37b1ac-67fa-4fff-a455-eda1fd18c965

updated settings toggle:
<img width="736" height="191" alt="image" src="https://github.com/user-attachments/assets/648e08a9-d082-4764-869a-725f877b17bf" />


