### PR TITLE
helium/core/sync: omit google device ids from private sync

### DIFF
--- a/patches/helium/core/sync/disable-google-backed-sync-integrations.patch
+++ b/patches/helium/core/sync/disable-google-backed-sync-integrations.patch
@@ -223,3 +223,24 @@
  }
  
  }  // namespace safe_browsing
+--- a/chrome/browser/sync/device_info_sync_client_impl.cc
++++ b/chrome/browser/sync/device_info_sync_client_impl.cc
+@@ -17,6 +17,7 @@
+ #include "chrome/browser/metrics/chrome_metrics_service_accessor.h"
+ #include "chrome/browser/profiles/profile.h"
+ #include "chrome/browser/signin/chrome_device_id_helper.h"
++#include "chrome/browser/sync/private_sync/private_sync_prefs.h"
+ #include "chrome/browser/sync/sync_invalidations_service_factory.h"
+ #include "components/sharing_message/sharing_sync_preference.h"
+ #include "components/sync/invalidations/sync_invalidations_service.h"
+@@ -46,6 +47,10 @@ std::string DeviceInfoSyncClientImpl::Ge
+   }
+ #endif  // BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX)
+ 
++  // This is Google sign-in metadata, not the device's Sync cache GUID.
++  if (private_sync_prefs::IsConfigured(*profile_->GetPrefs())) {
++    return {};
++  }
+   return GetSigninScopedDeviceIdForProfile(profile_);
+ }
+ 


### PR DESCRIPTION
leave the Google sign-in device ID empty when using private sync. devices are identified by their sync cache GUID instead

Related: #90
