### PR TITLE
helium/core/sync/provider: implement the extension API

### DIFF
--- a/patches/helium/core/sync/provider/api.patch
+++ b/patches/helium/core/sync/provider/api.patch
@@ -73,14 +73,18 @@
      "extension_types": ["extension", "platform_app"],
 --- a/chrome/common/extensions/api/api_sources.gni
 +++ b/chrome/common/extensions/api/api_sources.gni
-@@ -101,6 +101,7 @@ if (enable_extensions) {
+@@ -101,7 +101,10 @@ if (enable_extensions) {
    ]
  
    if (is_win || is_mac || is_linux) {
-+    types_only_schema_sources_ += [ "sync_vault_provider.webidl" ]
-     schema_sources_ += [ "web_authentication_proxy.webidl" ]
+-    schema_sources_ += [ "web_authentication_proxy.webidl" ]
++    schema_sources_ += [
++      "sync_vault_provider.webidl",
++      "web_authentication_proxy.webidl",
++    ]
    }
  
+   if (is_win || is_mac || is_linux || is_chromeos) {
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
 @@ -5477,6 +5477,9 @@ are declared in tools/grit/grit_args.gni
@@ -421,3 +425,187 @@
    UNKNOWN = 0,
    WEBNAVIGATION_GETALLFRAMES = 1,
    BROWSINGDATA_REMOVEWEBSQL = 2,
+--- a/chrome/browser/extensions/api/BUILD.gn
++++ b/chrome/browser/extensions/api/BUILD.gn
+@@ -79,6 +79,7 @@ group("api_implementations") {
+       "//chrome/browser/extensions/api/safe_browsing_private",
+       "//chrome/browser/extensions/api/settings_overrides",
+       "//chrome/browser/extensions/api/side_panel",
++      "//chrome/browser/extensions/api/sync_vault_provider",
+       "//chrome/browser/extensions/api/webrtc_desktop_capture_private",
+     ]
+ 
+--- a/chrome/browser/extensions/api/api_browser_context_keyed_service_factories.cc
++++ b/chrome/browser/extensions/api/api_browser_context_keyed_service_factories.cc
+@@ -45,6 +45,7 @@
+ #include "chrome/browser/extensions/api/settings_overrides/settings_overrides_api.h"
+ #include "chrome/browser/extensions/api/settings_private/settings_private_event_router_factory.h"
+ #include "chrome/browser/extensions/api/side_panel/side_panel_service.h"
++#include "chrome/browser/extensions/api/sync_vault_provider/sync_vault_provider_service.h"
+ #include "components/safe_browsing/buildflags.h"
+ #include "extensions/browser/api/networking_private/networking_private_delegate_factory.h"
+ #include "pdf/buildflags.h"
+@@ -140,6 +141,7 @@ void EnsureApiBrowserContextKeyedService
+   extensions::SettingsPrivateEventRouterFactory::GetInstance();
+   extensions::SettingsOverridesAPI::GetFactoryInstance();
+   extensions::SidePanelService::GetFactoryInstance();
++  extensions::SyncVaultProviderServiceFactory::GetInstance();
+ #if BUILDFLAG(IS_CHROMEOS)
+   extensions::TerminalPrivateAPI::GetFactoryInstance();
+   extensions::VerifyTrustApiService::GetFactoryInstance();
+--- /dev/null
++++ b/chrome/browser/extensions/api/sync_vault_provider/BUILD.gn
+@@ -0,0 +1,32 @@
++# Copyright 2026 The Helium Authors
++# You can use, redistribute, and/or modify this source code under
++# the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++import("//extensions/buildflags/buildflags.gni")
++
++assert(enable_extensions)
++
++source_set("sync_vault_provider") {
++  sources = [
++    "sync_vault_provider_api.cc",
++    "sync_vault_provider_api.h",
++    "sync_vault_provider_service.cc",
++    "sync_vault_provider_service.h",
++  ]
++
++  public_deps = [
++    "//base",
++    "//chrome/browser/profiles:profile",
++    "//chrome/common/extensions",
++    "//chrome/common/extensions/api",
++    "//components/keyed_service/core",
++    "//extensions/browser",
++    "//extensions/common",
++  ]
++
++  deps = [
++    "//components/sync/engine/sync_vault",
++    "//content/public/browser",
++    "//third_party/blink/public/mojom/service_worker:storage",
++  ]
++}
+--- /dev/null
++++ b/chrome/browser/extensions/api/sync_vault_provider/sync_vault_provider_api.cc
+@@ -0,0 +1,73 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++#include "chrome/browser/extensions/api/sync_vault_provider/sync_vault_provider_api.h"
++
++#include <optional>
++#include <utility>
++
++#include "chrome/browser/extensions/api/sync_vault_provider/sync_vault_provider_service.h"
++#include "chrome/common/extensions/api/sync_vault_provider.h"
++
++namespace extensions {
++
++namespace provider_api = api::sync_vault_provider;
++
++SyncVaultProviderRespondFunction::~SyncVaultProviderRespondFunction() = default;
++
++ExtensionFunction::ResponseAction SyncVaultProviderRespondFunction::Run() {
++  auto params = provider_api::Respond::Params::Create(args());
++  EXTENSION_FUNCTION_VALIDATE(params);
++  SyncVaultProviderService* service =
++      SyncVaultProviderServiceFactory::GetForBrowserContext(browser_context());
++  if (!service) {
++    return RespondNow(
++        Error("Sync vault providers are unavailable in this profile."));
++  }
++  std::optional<std::string> error =
++      service->Respond(extension_id(), std::move(params->response));
++  return error ? RespondNow(Error(std::move(*error)))
++               : RespondNow(NoArguments());
++}
++
++SyncVaultProviderNotifyVaultChangedFunction::
++    ~SyncVaultProviderNotifyVaultChangedFunction() = default;
++
++ExtensionFunction::ResponseAction
++SyncVaultProviderNotifyVaultChangedFunction::Run() {
++  auto params = provider_api::NotifyVaultChanged::Params::Create(args());
++  EXTENSION_FUNCTION_VALIDATE(params);
++  SyncVaultProviderService* service =
++      SyncVaultProviderServiceFactory::GetForBrowserContext(browser_context());
++  if (!service) {
++    return RespondNow(
++        Error("Sync vault providers are unavailable in this profile."));
++  }
++  std::optional<std::string> error =
++      service->NotifyVaultChanged(extension_id(), params->change);
++  return error ? RespondNow(Error(std::move(*error)))
++               : RespondNow(NoArguments());
++}
++
++SyncVaultProviderNotifyProviderStateChangedFunction::
++    ~SyncVaultProviderNotifyProviderStateChangedFunction() = default;
++
++ExtensionFunction::ResponseAction
++SyncVaultProviderNotifyProviderStateChangedFunction::Run() {
++  auto params =
++      provider_api::NotifyProviderStateChanged::Params::Create(args());
++  EXTENSION_FUNCTION_VALIDATE(params);
++  SyncVaultProviderService* service =
++      SyncVaultProviderServiceFactory::GetForBrowserContext(browser_context());
++  if (!service) {
++    return RespondNow(
++        Error("Sync vault providers are unavailable in this profile."));
++  }
++  std::optional<std::string> error =
++      service->NotifyProviderStateChanged(extension_id(), params->change.state);
++  return error ? RespondNow(Error(std::move(*error)))
++               : RespondNow(NoArguments());
++}
++
++}  // namespace extensions
+--- /dev/null
++++ b/chrome/browser/extensions/api/sync_vault_provider/sync_vault_provider_api.h
+@@ -0,0 +1,42 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++#ifndef CHROME_BROWSER_EXTENSIONS_API_SYNC_VAULT_PROVIDER_SYNC_VAULT_PROVIDER_API_H_
++#define CHROME_BROWSER_EXTENSIONS_API_SYNC_VAULT_PROVIDER_SYNC_VAULT_PROVIDER_API_H_
++
++#include "extensions/browser/extension_function.h"
++
++namespace extensions {
++
++class SyncVaultProviderRespondFunction : public ExtensionFunction {
++ private:
++  ~SyncVaultProviderRespondFunction() override;
++  ResponseAction Run() override;
++
++  DECLARE_EXTENSION_FUNCTION("syncVaultProvider.respond",
++                             SYNCVAULTPROVIDER_RESPOND)
++};
++
++class SyncVaultProviderNotifyVaultChangedFunction : public ExtensionFunction {
++ private:
++  ~SyncVaultProviderNotifyVaultChangedFunction() override;
++  ResponseAction Run() override;
++
++  DECLARE_EXTENSION_FUNCTION("syncVaultProvider.notifyVaultChanged",
++                             SYNCVAULTPROVIDER_NOTIFYVAULTCHANGED)
++};
++
++class SyncVaultProviderNotifyProviderStateChangedFunction
++    : public ExtensionFunction {
++ private:
++  ~SyncVaultProviderNotifyProviderStateChangedFunction() override;
++  ResponseAction Run() override;
++
++  DECLARE_EXTENSION_FUNCTION("syncVaultProvider.notifyProviderStateChanged",
++                             SYNCVAULTPROVIDER_NOTIFYPROVIDERSTATECHANGED)
++};
++
++}  // namespace extensions
++
++#endif  // CHROME_BROWSER_EXTENSIONS_API_SYNC_VAULT_PROVIDER_SYNC_VAULT_PROVIDER_API_H_

--- a/patches/helium/core/sync/provider/service.patch
+++ b/patches/helium/core/sync/provider/service.patch
@@ -33,7 +33,7 @@
 +}
 --- /dev/null
 +++ b/chrome/browser/extensions/api/sync_vault_provider/sync_vault_provider_service.cc
-@@ -0,0 +1,862 @@
+@@ -0,0 +1,968 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
@@ -50,6 +50,8 @@
 +#include "base/functional/bind.h"
 +#include "base/memory/ptr_util.h"
 +#include "base/strings/strcat.h"
++#include "base/task/single_thread_task_runner.h"
++#include "base/time/time.h"
 +#include "base/uuid.h"
 +#include "chrome/browser/profiles/profile_selections.h"
 +#include "chrome/common/extensions/api/sync_vault_provider/sync_vault_provider_manifest_handler.h"
@@ -60,7 +62,9 @@
 +#include "extensions/browser/event_router_factory.h"
 +#include "extensions/browser/extension_registry.h"
 +#include "extensions/browser/extension_registry_factory.h"
++#include "extensions/browser/process_manager_factory.h"
 +#include "extensions/common/extension.h"
++#include "third_party/blink/public/mojom/service_worker/service_worker_database.mojom.h"
 +
 +namespace extensions {
 +
@@ -68,8 +72,12 @@
 +
 +namespace provider_api = api::sync_vault_provider;
 +
++constexpr base::TimeDelta kProviderRequestTimeout = base::Minutes(2);
 +constexpr size_t kMaximumDisplayNameBytes = 128;
 +constexpr size_t kMaximumFailureMessageBytes = 16 * 1024;
++constexpr size_t kMaximumPendingRequests = 64;
++constexpr char kProviderRequestKeepaliveActivity[] =
++    "syncVaultProvider.request";
 +
 +bool IsValidVaultUuid(const std::string& value) {
 +  return base::Uuid::ParseLowercase(value).is_valid();
@@ -254,6 +262,7 @@
 +    return;
 +  }
 +
++  configuration_timeout_.Stop();
 +  active_configuration_request_id_.reset();
 +  DispatchCancellation(request_id);
 +}
@@ -463,6 +472,7 @@
 +    return;
 +  }
 +  if (it->second.type == RequestType::kConfigure) {
++    configuration_timeout_.Stop();
 +    active_configuration_request_id_.reset();
 +  }
 +  ResponseCallback callback = TakeRequestCallback(request_id);
@@ -512,12 +522,17 @@
 +    }
 +  }
 +  if (request_type == RequestType::kConfigure && !result.has_value()) {
++    configuration_timeout_.Stop();
 +    active_configuration_request_id_.reset();
 +  }
 +  ResponseCallback callback = TakeRequestCallback(request_id);
++  if (request_type == RequestType::kConfigure && result.has_value()) {
++    UpdateConfigurationTimeout(result->success->configuration_state);
++  }
 +  if (request_type == RequestType::kConfigure && result.has_value() &&
 +      result->success->configuration_state ==
 +          provider_api::ProviderConfigurationState::kReady) {
++    configuration_timeout_.Stop();
 +    active_configuration_request_id_.reset();
 +    selected_provider_state_ = provider_api::ProviderState::kReady;
 +    for (Observer& observer : observers_) {
@@ -532,6 +547,7 @@
 +std::optional<std::string>
 +SyncVaultProviderService::HandleConfigurationResponse(Response response) {
 +  if (!response.has_value()) {
++    configuration_timeout_.Stop();
 +    active_configuration_request_id_.reset();
 +    for (Observer& observer : observers_) {
 +      observer.OnSyncVaultProviderConfigurationFailed(response.error());
@@ -546,6 +562,7 @@
 +      success.key_envelope || success.vault_key) {
 +    return "The configuration progress response is invalid.";
 +  }
++  UpdateConfigurationTimeout(success.configuration_state);
 +  if (success.configuration_state !=
 +      provider_api::ProviderConfigurationState::kReady) {
 +    for (Observer& observer : observers_) {
@@ -554,6 +571,7 @@
 +    }
 +    return std::nullopt;
 +  }
++  configuration_timeout_.Stop();
 +  active_configuration_request_id_.reset();
 +  selected_provider_state_ = provider_api::ProviderState::kReady;
 +  for (Observer& observer : observers_) {
@@ -648,14 +666,28 @@
 +        request_id, provider_api::SyncVaultProviderError::kUnsupported)));
 +    return 0;
 +  }
++  if (pending_requests_.size() >= kMaximumPendingRequests) {
++    std::move(callback).Run(base::unexpected(MakeFailure(
++        request_id, provider_api::SyncVaultProviderError::kTemporaryError)));
++    return 0;
++  }
++
 +  const bool inserted =
 +      pending_requests_
 +          .emplace(request_id, PendingRequest{type, std::move(callback),
 +                                              maximum_response_bytes})
 +          .second;
 +  CHECK(inserted);
++  base::SingleThreadTaskRunner::GetCurrentDefault()->PostDelayedTask(
++      FROM_HERE,
++      base::BindOnce(&SyncVaultProviderService::OnRequestTimeout,
++                     weak_ptr_factory_.GetWeakPtr(), request_id),
++      kProviderRequestTimeout);
 +  auto event = std::make_unique<Event>(histogram_value, event_name,
 +                                       std::move(event_args), browser_context_);
++  event->did_dispatch_callback =
++      base::BindRepeating(&SyncVaultProviderService::OnRequestDispatched,
++                          weak_ptr_factory_.GetWeakPtr(), request_id);
 +  event_router_->DispatchEventToExtension(provider->id(), std::move(event));
 +  return request_id;
 +}
@@ -696,6 +728,78 @@
 +  next_request_id_ =
 +      result == std::numeric_limits<RequestId>::max() ? 1 : result + 1;
 +  return result;
++}
++
++void SyncVaultProviderService::OnRequestDispatched(RequestId request_id,
++                                                   const EventTarget& target) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  if (target.service_worker_version_id ==
++      blink::mojom::kInvalidServiceWorkerVersionId) {
++    return;
++  }
++  auto request = pending_requests_.find(request_id);
++  if (request == pending_requests_.end() || !selected_provider_id_ ||
++      target.extension_id != *selected_provider_id_) {
++    return;
++  }
++
++  WorkerId worker_id{
++      target.extension_id,
++      content::ChildProcessId::FromUnsafeValue(target.render_process_id),
++      target.service_worker_version_id, target.worker_thread_id};
++  for (const auto& keepalive : request->second.worker_keepalives) {
++    if (keepalive->worker_id() == worker_id) {
++      return;
++    }
++  }
++  request->second.worker_keepalives.push_back(
++      std::make_unique<ServiceWorkerKeepalive>(
++          browser_context_, std::move(worker_id),
++          content::ServiceWorkerExternalRequestTimeoutType::kDefault,
++          Activity::EVENT, kProviderRequestKeepaliveActivity));
++}
++
++void SyncVaultProviderService::OnRequestTimeout(RequestId request_id) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  auto it = pending_requests_.find(request_id);
++  if (it == pending_requests_.end()) {
++    return;
++  }
++  if (it->second.type == RequestType::kConfigure) {
++    configuration_timeout_.Stop();
++    active_configuration_request_id_.reset();
++  }
++  ResponseCallback callback = TakeRequestCallback(request_id);
++  DispatchCancellation(request_id);
++  std::move(callback).Run(base::unexpected(MakeFailure(
++      request_id, provider_api::SyncVaultProviderError::kTemporaryError)));
++}
++
++void SyncVaultProviderService::UpdateConfigurationTimeout(
++    provider_api::ProviderConfigurationState state) {
++  if (state != provider_api::ProviderConfigurationState::kConfiguring) {
++    configuration_timeout_.Stop();
++    return;
++  }
++  CHECK(active_configuration_request_id_);
++  configuration_timeout_.Start(
++      FROM_HERE, kProviderRequestTimeout,
++      base::BindOnce(&SyncVaultProviderService::OnConfigurationTimeout,
++                     weak_ptr_factory_.GetWeakPtr(),
++                     *active_configuration_request_id_));
++}
++
++void SyncVaultProviderService::OnConfigurationTimeout(RequestId request_id) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  if (active_configuration_request_id_ != request_id) {
++    return;
++  }
++  ProviderFailure failure = MakeFailure(
++      request_id, provider_api::SyncVaultProviderError::kTemporaryError);
++  CancelConfiguration(request_id);
++  for (Observer& observer : observers_) {
++    observer.OnSyncVaultProviderConfigurationFailed(failure);
++  }
 +}
 +
 +SyncVaultProviderService::ResponseCallback
@@ -799,6 +903,7 @@
 +      active_configuration_request_id_;
 +  auto pending = std::move(pending_requests_);
 +  pending_requests_.clear();
++  configuration_timeout_.Stop();
 +  active_configuration_request_id_.reset();
 +  if (configuration_to_cancel && !pending.contains(*configuration_to_cancel)) {
 +    DispatchCancellation(*configuration_to_cancel);
@@ -885,6 +990,7 @@
 +          ProfileSelections::BuildRedirectedInIncognito()) {
 +  DependsOn(EventRouterFactory::GetInstance());
 +  DependsOn(ExtensionRegistryFactory::GetInstance());
++  DependsOn(ProcessManagerFactory::GetInstance());
 +}
 +
 +SyncVaultProviderServiceFactory::~SyncVaultProviderServiceFactory() = default;
@@ -898,7 +1004,7 @@
 +}  // namespace extensions
 --- /dev/null
 +++ b/chrome/browser/extensions/api/sync_vault_provider/sync_vault_provider_service.h
-@@ -0,0 +1,244 @@
+@@ -0,0 +1,254 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
@@ -920,6 +1026,7 @@
 +#include "base/observer_list.h"
 +#include "base/scoped_observation.h"
 +#include "base/sequence_checker.h"
++#include "base/timer/timer.h"
 +#include "base/types/expected.h"
 +#include "base/values.h"
 +#include "chrome/browser/profiles/profile_keyed_service_factory.h"
@@ -927,6 +1034,7 @@
 +#include "components/keyed_service/core/keyed_service.h"
 +#include "extensions/browser/extension_event_histogram_value.h"
 +#include "extensions/browser/extension_registry_observer.h"
++#include "extensions/browser/service_worker/service_worker_keepalive.h"
 +#include "extensions/common/extension_id.h"
 +
 +namespace content {
@@ -938,6 +1046,7 @@
 +class EventRouter;
 +class Extension;
 +class ExtensionRegistry;
++struct EventTarget;
 +
 +class SyncVaultProviderService : public KeyedService,
 +                                 public ExtensionRegistryObserver {
@@ -1065,13 +1174,13 @@
 +    kCollectEpochs,
 +    kWrapKey,
 +    kUnwrapKey,
-+    kMaxValue = kUnwrapKey,
 +  };
 +
 +  struct PendingRequest {
 +    RequestType type;
 +    ResponseCallback callback;
 +    size_t maximum_response_bytes = 0;
++    std::vector<std::unique_ptr<ServiceWorkerKeepalive>> worker_keepalives;
 +  };
 +
 +  RequestId Dispatch(RequestId request_id,
@@ -1087,6 +1196,11 @@
 +  void DispatchCancellation(RequestId request_id);
 +  void CancelConfiguration(RequestId request_id);
 +  RequestId NewRequestId();
++  void OnRequestDispatched(RequestId request_id, const EventTarget& target);
++  void OnRequestTimeout(RequestId request_id);
++  void UpdateConfigurationTimeout(
++      api::sync_vault_provider::ProviderConfigurationState state);
++  void OnConfigurationTimeout(RequestId request_id);
 +  ResponseCallback TakeRequestCallback(RequestId request_id);
 +  std::optional<std::string> HandleConfigurationResponse(Response response);
 +  std::optional<std::string> ValidateSuccessResponse(
@@ -1114,6 +1228,8 @@
 +  std::optional<api::sync_vault_provider::ProviderState>
 +      selected_provider_state_;
 +  std::optional<RequestId> active_configuration_request_id_;
++  // Bounds background configuration work, not time spent waiting for the user.
++  base::OneShotTimer configuration_timeout_;
 +  std::map<RequestId, PendingRequest> pending_requests_;
 +  RequestId next_request_id_ = 1;
 +  base::ObserverList<Observer> observers_;

--- a/patches/helium/core/sync/provider/service.patch
+++ b/patches/helium/core/sync/provider/service.patch
@@ -1,37 +1,4 @@
 --- /dev/null
-+++ b/chrome/browser/extensions/api/sync_vault_provider/BUILD.gn
-@@ -0,0 +1,30 @@
-+# Copyright 2026 The Helium Authors
-+# You can use, redistribute, and/or modify this source code under
-+# the terms of the GPL-3.0 license that can be found in the LICENSE file.
-+
-+import("//extensions/buildflags/buildflags.gni")
-+
-+assert(enable_extensions)
-+
-+source_set("sync_vault_provider") {
-+  sources = [
-+    "sync_vault_provider_service.cc",
-+    "sync_vault_provider_service.h",
-+  ]
-+
-+  public_deps = [
-+    "//base",
-+    "//chrome/browser/profiles:profile",
-+    "//chrome/common/extensions",
-+    "//chrome/common/extensions/api",
-+    "//components/keyed_service/core",
-+    "//extensions/browser",
-+    "//extensions/common",
-+  ]
-+
-+  deps = [
-+    "//components/sync/engine/sync_vault",
-+    "//content/public/browser",
-+    "//third_party/blink/public/mojom/service_worker:storage",
-+  ]
-+}
---- /dev/null
 +++ b/chrome/browser/extensions/api/sync_vault_provider/sync_vault_provider_service.cc
 @@ -0,0 +1,968 @@
 +// Copyright 2026 The Helium Authors

--- a/patches/helium/core/sync/provider/service.patch
+++ b/patches/helium/core/sync/provider/service.patch
@@ -33,7 +33,7 @@
 +}
 --- /dev/null
 +++ b/chrome/browser/extensions/api/sync_vault_provider/sync_vault_provider_service.cc
-@@ -0,0 +1,595 @@
+@@ -0,0 +1,862 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
@@ -42,12 +42,14 @@
 +
 +#include <algorithm>
 +#include <limits>
++#include <set>
 +#include <string_view>
 +#include <utility>
 +
 +#include "base/check.h"
 +#include "base/functional/bind.h"
 +#include "base/memory/ptr_util.h"
++#include "base/strings/strcat.h"
 +#include "base/uuid.h"
 +#include "chrome/browser/profiles/profile_selections.h"
 +#include "chrome/common/extensions/api/sync_vault_provider/sync_vault_provider_manifest_handler.h"
@@ -67,6 +69,7 @@
 +namespace provider_api = api::sync_vault_provider;
 +
 +constexpr size_t kMaximumDisplayNameBytes = 128;
++constexpr size_t kMaximumFailureMessageBytes = 16 * 1024;
 +
 +bool IsValidVaultUuid(const std::string& value) {
 +  return base::Uuid::ParseLowercase(value).is_valid();
@@ -74,6 +77,37 @@
 +
 +std::optional<std::string> SanitizeDisplayName(std::string_view value) {
 +  return SanitizeSyncVaultProviderDisplayText(value, kMaximumDisplayNameBytes);
++}
++
++bool ValidateVaultList(std::vector<provider_api::VaultInfo>& vaults) {
++  std::set<std::string> vault_uuids;
++  for (provider_api::VaultInfo& vault : vaults) {
++    auto display_name = SanitizeDisplayName(vault.display_name);
++    if (!display_name || !IsValidVaultUuid(vault.vault_uuid) ||
++        !vault_uuids.insert(vault.vault_uuid).second) {
++      return false;
++    }
++    vault.display_name = std::move(*display_name);
++  }
++  return true;
++}
++
++std::optional<SyncVaultProviderService::ProviderFailure> ParseProviderFailure(
++    SyncVaultProviderService::RequestId request_id,
++    provider_api::ProviderFailure failure) {
++  if (failure.error == provider_api::SyncVaultProviderError::kNone) {
++    return std::nullopt;
++  }
++  if (failure.message) {
++    auto message = SanitizeSyncVaultProviderDisplayText(
++        *failure.message, kMaximumFailureMessageBytes);
++    if (!message) {
++      return std::nullopt;
++    }
++    failure.message = std::move(*message);
++  }
++  return SyncVaultProviderService::ProviderFailure{request_id, failure.error,
++                                                   std::move(failure.message)};
 +}
 +
 +}  // namespace
@@ -130,6 +164,7 @@
 +  auto fail_pending =
 +      CancelPendingRequests(provider_api::SyncVaultProviderError::kAborted);
 +  selected_provider_id_ = extension_id;
++  selected_provider_state_.reset();
 +  for (Observer& observer : observers_) {
 +    observer.OnSyncVaultProviderSelectionChanged(selected_provider_id_);
 +    observer.OnSyncVaultProviderAvailabilityChanged(true);
@@ -147,6 +182,7 @@
 +  auto fail_pending =
 +      CancelPendingRequests(provider_api::SyncVaultProviderError::kAborted);
 +  selected_provider_id_.reset();
++  selected_provider_state_.reset();
 +  for (Observer& observer : observers_) {
 +    observer.OnSyncVaultProviderSelectionChanged(std::nullopt);
 +    if (was_available) {
@@ -429,11 +465,136 @@
 +  if (it->second.type == RequestType::kConfigure) {
 +    active_configuration_request_id_.reset();
 +  }
-+  ResponseCallback callback = std::move(it->second.callback);
-+  pending_requests_.erase(it);
++  ResponseCallback callback = TakeRequestCallback(request_id);
 +  DispatchCancellation(request_id);
 +  std::move(callback).Run(base::unexpected(
 +      MakeFailure(request_id, provider_api::SyncVaultProviderError::kAborted)));
++}
++
++std::optional<std::string> SyncVaultProviderService::Respond(
++    const ExtensionId& extension_id,
++    ProviderResponse response) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  if (!IsSelectedExtension(extension_id)) {
++    return "Only the selected sync vault provider may respond to requests.";
++  }
++  if (response.success.has_value() == response.failure.has_value()) {
++    return "A provider response must contain exactly one of success or "
++           "failure.";
++  }
++
++  const RequestId request_id = response.request_id;
++  Response result(std::move(response));
++  if (result->failure) {
++    auto failure =
++        ParseProviderFailure(request_id, std::move(*result->failure));
++    if (!failure) {
++      return "The provider failure response is invalid.";
++    }
++    result = base::unexpected(std::move(*failure));
++  }
++
++  auto it = pending_requests_.find(request_id);
++  if (it == pending_requests_.end()) {
++    if (active_configuration_request_id_ != request_id) {
++      return "Invalid or expired requestId.";
++    }
++    return HandleConfigurationResponse(std::move(result));
++  }
++
++  const RequestType request_type = it->second.type;
++  std::optional<std::string> error;
++  if (result.has_value()) {
++    error = ValidateSuccessResponse(it->second, *result->success);
++    if (error) {
++      result = base::unexpected(MakeFailure(
++          request_id, provider_api::SyncVaultProviderError::kInvalidData));
++    }
++  }
++  if (request_type == RequestType::kConfigure && !result.has_value()) {
++    active_configuration_request_id_.reset();
++  }
++  ResponseCallback callback = TakeRequestCallback(request_id);
++  if (request_type == RequestType::kConfigure && result.has_value() &&
++      result->success->configuration_state ==
++          provider_api::ProviderConfigurationState::kReady) {
++    active_configuration_request_id_.reset();
++    selected_provider_state_ = provider_api::ProviderState::kReady;
++    for (Observer& observer : observers_) {
++      observer.OnSyncVaultProviderStateChanged(
++          provider_api::ProviderState::kReady);
++    }
++  }
++  std::move(callback).Run(std::move(result));
++  return error;
++}
++
++std::optional<std::string>
++SyncVaultProviderService::HandleConfigurationResponse(Response response) {
++  if (!response.has_value()) {
++    active_configuration_request_id_.reset();
++    for (Observer& observer : observers_) {
++      observer.OnSyncVaultProviderConfigurationFailed(response.error());
++    }
++    return std::nullopt;
++  }
++
++  const provider_api::ProviderSuccess& success = *response->success;
++  if (success.configuration_state ==
++          provider_api::ProviderConfigurationState::kNone ||
++      success.vaults || success.data || success.revision ||
++      success.key_envelope || success.vault_key) {
++    return "The configuration progress response is invalid.";
++  }
++  if (success.configuration_state !=
++      provider_api::ProviderConfigurationState::kReady) {
++    for (Observer& observer : observers_) {
++      observer.OnSyncVaultProviderConfigurationStateChanged(
++          success.configuration_state);
++    }
++    return std::nullopt;
++  }
++  active_configuration_request_id_.reset();
++  selected_provider_state_ = provider_api::ProviderState::kReady;
++  for (Observer& observer : observers_) {
++    observer.OnSyncVaultProviderStateChanged(
++        provider_api::ProviderState::kReady);
++    observer.OnSyncVaultProviderConfigurationCompleted();
++  }
++  return std::nullopt;
++}
++
++std::optional<std::string> SyncVaultProviderService::NotifyVaultChanged(
++    const ExtensionId& extension_id,
++    const provider_api::VaultChange& change) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  if (!IsSelectedExtension(extension_id)) {
++    return "Only the selected sync vault provider may send notifications.";
++  }
++  if (!IsValidVaultUuid(change.vault_uuid)) {
++    return "The vault change contains an invalid identifier.";
++  }
++  for (Observer& observer : observers_) {
++    observer.OnSyncVaultChanged(change.vault_uuid);
++  }
++  return std::nullopt;
++}
++
++std::optional<std::string> SyncVaultProviderService::NotifyProviderStateChanged(
++    const ExtensionId& extension_id,
++    provider_api::ProviderState state) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  if (!IsSelectedExtension(extension_id)) {
++    return "Only the selected sync vault provider may send notifications.";
++  }
++  if (state == provider_api::ProviderState::kNone) {
++    return "The provider state is invalid.";
++  }
++  selected_provider_state_ = state;
++  for (Observer& observer : observers_) {
++    observer.OnSyncVaultProviderStateChanged(state);
++  }
++  return std::nullopt;
 +}
 +
 +void SyncVaultProviderService::AddObserver(Observer* observer) {
@@ -458,6 +619,7 @@
 +  auto fail_pending =
 +      CancelPendingRequests(provider_api::SyncVaultProviderError::kAborted);
 +  selected_provider_id_.reset();
++  selected_provider_state_.reset();
 +  std::move(fail_pending).Run();
 +}
 +
@@ -536,6 +698,101 @@
 +  return result;
 +}
 +
++SyncVaultProviderService::ResponseCallback
++SyncVaultProviderService::TakeRequestCallback(RequestId request_id) {
++  auto it = pending_requests_.find(request_id);
++  CHECK(it != pending_requests_.end());
++  ResponseCallback callback = std::move(it->second.callback);
++  pending_requests_.erase(it);
++  return callback;
++}
++
++std::optional<std::string> SyncVaultProviderService::ValidateSuccessResponse(
++    const PendingRequest& request,
++    provider_api::ProviderSuccess& success) const {
++  constexpr char kUnexpectedFields[] =
++      "Provider response contains fields not used by this operation.";
++  const bool has_configuration =
++      success.configuration_state !=
++      provider_api::ProviderConfigurationState::kNone;
++  const char* missing = nullptr;
++  switch (request.type) {
++    case RequestType::kConfigure:
++      if (success.vaults || success.data || success.revision ||
++          success.key_envelope || success.vault_key) {
++        return kUnexpectedFields;
++      }
++      missing = has_configuration ? nullptr : "a valid configuration state";
++      break;
++    case RequestType::kRenameVault:
++    case RequestType::kCreateVault:
++    case RequestType::kCollectEpochs:
++      if (has_configuration || success.vaults || success.data ||
++          success.revision || success.key_envelope || success.vault_key) {
++        return kUnexpectedFields;
++      }
++      return std::nullopt;
++    case RequestType::kListVaults:
++      if (has_configuration || success.data || success.revision ||
++          success.key_envelope || success.vault_key) {
++        return kUnexpectedFields;
++      }
++      missing = success.vaults && ValidateVaultList(*success.vaults)
++                    ? nullptr
++                    : "a valid vaults list";
++      break;
++    case RequestType::kReadObject:
++      if (has_configuration || success.vaults || success.key_envelope ||
++          success.vault_key) {
++        return kUnexpectedFields;
++      }
++      if (success.revision &&
++          syncer::IsValidSyncVaultRevision(*success.revision) && success.data &&
++          !success.data->empty() &&
++          success.data->size() <= request.maximum_response_bytes) {
++        return std::nullopt;
++      }
++      missing = "complete object data and revision";
++      break;
++    case RequestType::kWriteObject:
++      if (has_configuration || success.vaults || success.data ||
++          success.key_envelope || success.vault_key) {
++        return kUnexpectedFields;
++      }
++      if (!success.revision ||
++          !syncer::IsValidSyncVaultRevision(*success.revision)) {
++        missing = "revision";
++      }
++      break;
++    case RequestType::kWrapKey:
++      if (has_configuration || success.vaults || success.data ||
++          success.revision || success.vault_key) {
++        return kUnexpectedFields;
++      }
++      missing = success.key_envelope && !success.key_envelope->empty() &&
++                        success.key_envelope->size() <=
++                            syncer::kSyncVaultMaximumEncryptedObjectBytes
++                    ? nullptr
++                    : "keyEnvelope";
++      break;
++    case RequestType::kUnwrapKey:
++      if (has_configuration || success.vaults || success.data ||
++          success.revision || success.key_envelope) {
++        return kUnexpectedFields;
++      }
++      missing =
++          success.vault_key && success.vault_key->size() ==
++                                   syncer::SyncVaultCryptographer::kVaultKeySize
++              ? nullptr
++              : "a 32-byte vaultKey";
++      break;
++  }
++  if (!missing) {
++    return std::nullopt;
++  }
++  return base::StrCat({"Provider response is missing ", missing, "."});
++}
++
 +base::OnceClosure SyncVaultProviderService::CancelPendingRequests(
 +    provider_api::SyncVaultProviderError error) {
 +  const std::optional<RequestId> configuration_to_cancel =
@@ -571,12 +828,19 @@
 +  return failure;
 +}
 +
++bool SyncVaultProviderService::IsSelectedExtension(
++    const ExtensionId& extension_id) const {
++  return selected_provider_id_ && *selected_provider_id_ == extension_id &&
++         GetSelectedProvider();
++}
++
 +void SyncVaultProviderService::OnExtensionLoaded(
 +    content::BrowserContext* browser_context,
 +    const Extension* extension) {
 +  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
 +  if (selected_provider_id_ && *selected_provider_id_ == extension->id() &&
 +      SyncVaultProviderInfo::Get(extension)) {
++    selected_provider_state_.reset();
 +    for (Observer& observer : observers_) {
 +      observer.OnSyncVaultProviderAvailabilityChanged(true);
 +    }
@@ -591,8 +855,11 @@
 +  if (selected_provider_id_ && *selected_provider_id_ == extension->id()) {
 +    auto fail_pending =
 +        CancelPendingRequests(provider_api::SyncVaultProviderError::kAborted);
++    selected_provider_state_ = provider_api::ProviderState::kOffline;
 +    for (Observer& observer : observers_) {
 +      observer.OnSyncVaultProviderAvailabilityChanged(false);
++      observer.OnSyncVaultProviderStateChanged(
++          provider_api::ProviderState::kOffline);
 +    }
 +    std::move(fail_pending).Run();
 +  }
@@ -631,7 +898,7 @@
 +}  // namespace extensions
 --- /dev/null
 +++ b/chrome/browser/extensions/api/sync_vault_provider/sync_vault_provider_service.h
-@@ -0,0 +1,215 @@
+@@ -0,0 +1,244 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
@@ -706,6 +973,14 @@
 +
 +  class Observer : public base::CheckedObserver {
 +   public:
++    virtual void OnSyncVaultChanged(const std::string& vault_uuid) {}
++    virtual void OnSyncVaultProviderStateChanged(
++        api::sync_vault_provider::ProviderState state) {}
++    virtual void OnSyncVaultProviderConfigurationStateChanged(
++        api::sync_vault_provider::ProviderConfigurationState state) {}
++    virtual void OnSyncVaultProviderConfigurationCompleted() {}
++    virtual void OnSyncVaultProviderConfigurationFailed(
++        const ProviderFailure& failure) {}
 +    virtual void OnSyncVaultProviderSelectionChanged(
 +        const std::optional<ExtensionId>& extension_id) {}
 +    virtual void OnSyncVaultProviderAvailabilityChanged(bool available) {}
@@ -726,6 +1001,11 @@
 +  const Extension* GetSelectedProvider() const;
 +  const std::optional<ExtensionId>& selected_provider_id() const {
 +    return selected_provider_id_;
++  }
++
++  const std::optional<api::sync_vault_provider::ProviderState>&
++  selected_provider_state() const {
++    return selected_provider_state_;
 +  }
 +
 +  [[nodiscard]] std::unique_ptr<ConfigurationSession> Configure(
@@ -758,6 +1038,14 @@
 +                      ResponseCallback callback);
 +  void CancelRequest(RequestId request_id);
 +
++  std::optional<std::string> Respond(const ExtensionId& extension_id,
++                                     ProviderResponse response);
++  std::optional<std::string> NotifyVaultChanged(
++      const ExtensionId& extension_id,
++      const api::sync_vault_provider::VaultChange& change);
++  std::optional<std::string> NotifyProviderStateChanged(
++      const ExtensionId& extension_id,
++      api::sync_vault_provider::ProviderState state);
 +  void AddObserver(Observer* observer);
 +  void RemoveObserver(Observer* observer);
 +
@@ -799,11 +1087,17 @@
 +  void DispatchCancellation(RequestId request_id);
 +  void CancelConfiguration(RequestId request_id);
 +  RequestId NewRequestId();
++  ResponseCallback TakeRequestCallback(RequestId request_id);
++  std::optional<std::string> HandleConfigurationResponse(Response response);
++  std::optional<std::string> ValidateSuccessResponse(
++      const PendingRequest& request,
++      api::sync_vault_provider::ProviderSuccess& success) const;
 +  [[nodiscard]] base::OnceClosure CancelPendingRequests(
 +      api::sync_vault_provider::SyncVaultProviderError error);
 +  ProviderFailure MakeFailure(
 +      RequestId request_id,
 +      api::sync_vault_provider::SyncVaultProviderError error) const;
++  bool IsSelectedExtension(const ExtensionId& extension_id) const;
 +
 +  // ExtensionRegistryObserver:
 +  void OnExtensionLoaded(content::BrowserContext* browser_context,
@@ -817,6 +1111,8 @@
 +  raw_ptr<ExtensionRegistry> extension_registry_;
 +  std::optional<ExtensionId> selected_provider_id_;
 +  bool shutting_down_ = false;
++  std::optional<api::sync_vault_provider::ProviderState>
++      selected_provider_state_;
 +  std::optional<RequestId> active_configuration_request_id_;
 +  std::map<RequestId, PendingRequest> pending_requests_;
 +  RequestId next_request_id_ = 1;

--- a/patches/helium/core/sync/provider/service.patch
+++ b/patches/helium/core/sync/provider/service.patch
@@ -1,6 +1,6 @@
 --- /dev/null
 +++ b/chrome/browser/extensions/api/sync_vault_provider/BUILD.gn
-@@ -0,0 +1,23 @@
+@@ -0,0 +1,30 @@
 +# Copyright 2026 The Helium Authors
 +# You can use, redistribute, and/or modify this source code under
 +# the terms of the GPL-3.0 license that can be found in the LICENSE file.
@@ -19,34 +19,82 @@
 +    "//base",
 +    "//chrome/browser/profiles:profile",
 +    "//chrome/common/extensions",
++    "//chrome/common/extensions/api",
 +    "//components/keyed_service/core",
 +    "//extensions/browser",
 +    "//extensions/common",
 +  ]
++
++  deps = [
++    "//components/sync/engine/sync_vault",
++    "//content/public/browser",
++    "//third_party/blink/public/mojom/service_worker:storage",
++  ]
 +}
 --- /dev/null
 +++ b/chrome/browser/extensions/api/sync_vault_provider/sync_vault_provider_service.cc
-@@ -0,0 +1,153 @@
+@@ -0,0 +1,595 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
 +
 +#include "chrome/browser/extensions/api/sync_vault_provider/sync_vault_provider_service.h"
 +
++#include <algorithm>
++#include <limits>
++#include <string_view>
 +#include <utility>
 +
 +#include "base/check.h"
++#include "base/functional/bind.h"
++#include "base/memory/ptr_util.h"
++#include "base/uuid.h"
 +#include "chrome/browser/profiles/profile_selections.h"
 +#include "chrome/common/extensions/api/sync_vault_provider/sync_vault_provider_manifest_handler.h"
++#include "components/sync/engine/sync_vault/sync_vault_cryptographer.h"
++#include "components/sync/engine/sync_vault/sync_vault_limits.h"
++#include "content/public/browser/service_worker_external_request_timeout_type.h"
++#include "extensions/browser/event_router.h"
++#include "extensions/browser/event_router_factory.h"
 +#include "extensions/browser/extension_registry.h"
 +#include "extensions/browser/extension_registry_factory.h"
 +#include "extensions/common/extension.h"
 +
 +namespace extensions {
 +
++namespace {
++
++namespace provider_api = api::sync_vault_provider;
++
++constexpr size_t kMaximumDisplayNameBytes = 128;
++
++bool IsValidVaultUuid(const std::string& value) {
++  return base::Uuid::ParseLowercase(value).is_valid();
++}
++
++std::optional<std::string> SanitizeDisplayName(std::string_view value) {
++  return SanitizeSyncVaultProviderDisplayText(value, kMaximumDisplayNameBytes);
++}
++
++}  // namespace
++
++SyncVaultProviderService::ConfigurationSession::ConfigurationSession(
++    base::WeakPtr<SyncVaultProviderService> service,
++    RequestId request_id)
++    : service_(std::move(service)), request_id_(request_id) {}
++
++SyncVaultProviderService::ConfigurationSession::~ConfigurationSession() {
++  if (service_) {
++    service_->CancelConfiguration(request_id_);
++  }
++}
++
 +SyncVaultProviderService::SyncVaultProviderService(
 +    content::BrowserContext* browser_context)
-+    : extension_registry_(ExtensionRegistry::Get(browser_context)) {
++    : browser_context_(browser_context),
++      event_router_(EventRouter::Get(browser_context)),
++      extension_registry_(ExtensionRegistry::Get(browser_context)) {
++  CHECK(event_router_);
 +  CHECK(extension_registry_);
 +  registry_observation_.Observe(extension_registry_);
 +}
@@ -68,6 +116,9 @@
 +
 +bool SyncVaultProviderService::SelectProvider(const ExtensionId& extension_id) {
 +  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  if (shutting_down_) {
++    return false;
++  }
 +  const Extension* extension =
 +      extension_registry_->enabled_extensions().GetByID(extension_id);
 +  if (!extension || !SyncVaultProviderInfo::Get(extension)) {
@@ -76,11 +127,14 @@
 +  if (selected_provider_id_ == extension_id) {
 +    return true;
 +  }
++  auto fail_pending =
++      CancelPendingRequests(provider_api::SyncVaultProviderError::kAborted);
 +  selected_provider_id_ = extension_id;
 +  for (Observer& observer : observers_) {
 +    observer.OnSyncVaultProviderSelectionChanged(selected_provider_id_);
 +    observer.OnSyncVaultProviderAvailabilityChanged(true);
 +  }
++  std::move(fail_pending).Run();
 +  return true;
 +}
 +
@@ -90,6 +144,8 @@
 +    return;
 +  }
 +  const bool was_available = GetSelectedProvider() != nullptr;
++  auto fail_pending =
++      CancelPendingRequests(provider_api::SyncVaultProviderError::kAborted);
 +  selected_provider_id_.reset();
 +  for (Observer& observer : observers_) {
 +    observer.OnSyncVaultProviderSelectionChanged(std::nullopt);
@@ -97,6 +153,7 @@
 +      observer.OnSyncVaultProviderAvailabilityChanged(false);
 +    }
 +  }
++  std::move(fail_pending).Run();
 +}
 +
 +const Extension* SyncVaultProviderService::GetSelectedProvider() const {
@@ -110,6 +167,275 @@
 +                                                            : nullptr;
 +}
 +
++std::unique_ptr<SyncVaultProviderService::ConfigurationSession>
++SyncVaultProviderService::Configure(ResponseCallback callback) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  if (shutting_down_) {
++    std::move(callback).Run(base::unexpected(
++        MakeFailure(0, provider_api::SyncVaultProviderError::kAborted)));
++    return nullptr;
++  }
++  if (active_configuration_request_id_) {
++    std::move(callback).Run(base::unexpected(
++        MakeFailure(0, provider_api::SyncVaultProviderError::kTemporaryError)));
++    return nullptr;
++  }
++  provider_api::ProviderRequest request;
++  request.request_id = NewRequestId();
++  active_configuration_request_id_ = request.request_id;
++  auto weak_this = GetWeakPtr();
++  const RequestId dispatched = Dispatch(
++      request.request_id, RequestType::kConfigure,
++      events::SYNC_VAULT_PROVIDER_ON_CONFIGURE_REQUESTED,
++      provider_api::OnConfigureRequested::kEventName,
++      provider_api::OnConfigureRequested::Create(request),
++      base::BindOnce(
++          [](base::WeakPtr<SyncVaultProviderService> service,
++             RequestId request_id, ResponseCallback callback,
++             Response response) {
++            // A synchronous rejection must not block a retry from the callback.
++            if (!response.has_value() && service &&
++                service->active_configuration_request_id_ == request_id) {
++              service->active_configuration_request_id_.reset();
++            }
++            std::move(callback).Run(std::move(response));
++          },
++          weak_this, request.request_id, std::move(callback)));
++  if (!dispatched || !weak_this) {
++    return nullptr;
++  }
++  return base::WrapUnique(new ConfigurationSession(weak_this, dispatched));
++}
++
++void SyncVaultProviderService::CancelConfiguration(RequestId request_id) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  if (active_configuration_request_id_ != request_id) {
++    return;
++  }
++
++  if (pending_requests_.contains(request_id)) {
++    CancelRequest(request_id);
++    return;
++  }
++
++  active_configuration_request_id_.reset();
++  DispatchCancellation(request_id);
++}
++
++SyncVaultProviderService::RequestId SyncVaultProviderService::ListVaults(
++    ResponseCallback callback) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  provider_api::ProviderRequest request;
++  request.request_id = NewRequestId();
++  return Dispatch(request.request_id, RequestType::kListVaults,
++                  events::SYNC_VAULT_PROVIDER_ON_LIST_VAULTS_REQUESTED,
++                  provider_api::OnListVaultsRequested::kEventName,
++                  provider_api::OnListVaultsRequested::Create(request),
++                  std::move(callback));
++}
++
++SyncVaultProviderService::RequestId SyncVaultProviderService::CreateVault(
++    const std::string& vault_uuid,
++    const std::string& display_name,
++    ResponseCallback callback) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  std::optional<std::string> sanitized_display_name =
++      SanitizeDisplayName(display_name);
++  if (!IsValidVaultUuid(vault_uuid) || !sanitized_display_name) {
++    std::move(callback).Run(base::unexpected(
++        MakeFailure(0, provider_api::SyncVaultProviderError::kInvalidData)));
++    return 0;
++  }
++  provider_api::CreateVaultRequest request;
++  request.request_id = NewRequestId();
++  request.vault_uuid = vault_uuid;
++  request.display_name = std::move(*sanitized_display_name);
++  return Dispatch(request.request_id, RequestType::kCreateVault,
++                  events::SYNC_VAULT_PROVIDER_ON_CREATE_VAULT_REQUESTED,
++                  provider_api::OnCreateVaultRequested::kEventName,
++                  provider_api::OnCreateVaultRequested::Create(request),
++                  std::move(callback));
++}
++
++SyncVaultProviderService::RequestId SyncVaultProviderService::RenameVault(
++    const std::string& vault_uuid,
++    const std::string& display_name,
++    ResponseCallback callback) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  std::optional<std::string> sanitized_display_name =
++      SanitizeDisplayName(display_name);
++  if (!IsValidVaultUuid(vault_uuid) || !sanitized_display_name) {
++    std::move(callback).Run(base::unexpected(
++        MakeFailure(0, provider_api::SyncVaultProviderError::kInvalidData)));
++    return 0;
++  }
++  provider_api::RenameVaultRequest request;
++  request.request_id = NewRequestId();
++  request.vault_uuid = vault_uuid;
++  request.display_name = std::move(*sanitized_display_name);
++  return Dispatch(request.request_id, RequestType::kRenameVault,
++                  events::SYNC_VAULT_PROVIDER_ON_RENAME_VAULT_REQUESTED,
++                  provider_api::OnRenameVaultRequested::kEventName,
++                  provider_api::OnRenameVaultRequested::Create(request),
++                  std::move(callback));
++}
++
++SyncVaultProviderService::RequestId SyncVaultProviderService::ReadObject(
++    const std::string& vault_uuid,
++    const std::string& object_id,
++    int max_bytes,
++    ResponseCallback callback) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  if (!IsValidVaultUuid(vault_uuid) ||
++      !syncer::IsValidSyncVaultObjectId(object_id) || max_bytes <= 0 ||
++      static_cast<uint64_t>(max_bytes) >
++          syncer::kSyncVaultMaximumEncryptedObjectBytes) {
++    std::move(callback).Run(base::unexpected(
++        MakeFailure(0, provider_api::SyncVaultProviderError::kInvalidData)));
++    return 0;
++  }
++  provider_api::ReadObjectRequest request;
++  request.request_id = NewRequestId();
++  request.vault_uuid = vault_uuid;
++  request.object_id = object_id;
++  request.max_bytes = max_bytes;
++  return Dispatch(request.request_id, RequestType::kReadObject,
++                  events::SYNC_VAULT_PROVIDER_ON_READ_OBJECT_REQUESTED,
++                  provider_api::OnReadObjectRequested::kEventName,
++                  provider_api::OnReadObjectRequested::Create(request),
++                  std::move(callback), max_bytes);
++}
++
++SyncVaultProviderService::RequestId SyncVaultProviderService::WriteObject(
++    const std::string& vault_uuid,
++    const std::string& object_id,
++    std::vector<uint8_t> data,
++    std::optional<std::string> expected_revision,
++    std::optional<int> retention_epoch,
++    ResponseCallback callback) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  if (!IsValidVaultUuid(vault_uuid) ||
++      !syncer::IsValidSyncVaultObjectId(object_id) ||
++      (expected_revision &&
++       !syncer::IsValidSyncVaultRevision(*expected_revision)) ||
++      (retention_epoch && *retention_epoch < 0) || data.empty() ||
++      data.size() > syncer::kSyncVaultMaximumEncryptedObjectBytes) {
++    std::move(callback).Run(base::unexpected(
++        MakeFailure(0, provider_api::SyncVaultProviderError::kInvalidData)));
++    return 0;
++  }
++
++  provider_api::WriteObjectRequest request;
++  request.request_id = NewRequestId();
++  request.vault_uuid = vault_uuid;
++  request.object_id = object_id;
++  request.data = std::move(data);
++  request.expected_revision = std::move(expected_revision);
++  request.retention_epoch = retention_epoch;
++  return Dispatch(request.request_id, RequestType::kWriteObject,
++                  events::SYNC_VAULT_PROVIDER_ON_WRITE_OBJECT_REQUESTED,
++                  provider_api::OnWriteObjectRequested::kEventName,
++                  provider_api::OnWriteObjectRequested::Create(request),
++                  std::move(callback));
++}
++
++SyncVaultProviderService::RequestId SyncVaultProviderService::CollectEpochs(
++    const std::string& vault_uuid,
++    int minimum_retained_epoch,
++    ResponseCallback callback) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  if (!IsValidVaultUuid(vault_uuid) || minimum_retained_epoch <= 0) {
++    std::move(callback).Run(base::unexpected(
++        MakeFailure(0, provider_api::SyncVaultProviderError::kInvalidData)));
++    return 0;
++  }
++  provider_api::CollectEpochsRequest request;
++  request.request_id = NewRequestId();
++  request.vault_uuid = vault_uuid;
++  request.minimum_retained_epoch = minimum_retained_epoch;
++  return Dispatch(request.request_id, RequestType::kCollectEpochs,
++                  events::SYNC_VAULT_PROVIDER_ON_COLLECT_EPOCHS_REQUESTED,
++                  provider_api::OnCollectEpochsRequested::kEventName,
++                  provider_api::OnCollectEpochsRequested::Create(request),
++                  std::move(callback));
++}
++
++SyncVaultProviderService::RequestId SyncVaultProviderService::WrapKey(
++    const std::string& vault_uuid,
++    std::vector<uint8_t> vault_key,
++    ResponseCallback callback) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  const Extension* provider = GetSelectedProvider();
++  const SyncVaultProviderInfo* info =
++      provider ? SyncVaultProviderInfo::Get(provider) : nullptr;
++  if (!info || !info->account_key()) {
++    std::move(callback).Run(base::unexpected(
++        MakeFailure(0, provider_api::SyncVaultProviderError::kUnsupported)));
++    return 0;
++  }
++  if (!IsValidVaultUuid(vault_uuid) ||
++      vault_key.size() != syncer::SyncVaultCryptographer::kVaultKeySize) {
++    std::move(callback).Run(base::unexpected(
++        MakeFailure(0, provider_api::SyncVaultProviderError::kInvalidData)));
++    return 0;
++  }
++  provider_api::WrapKeyRequest request;
++  request.request_id = NewRequestId();
++  request.vault_uuid = vault_uuid;
++  request.vault_key = std::move(vault_key);
++  return Dispatch(request.request_id, RequestType::kWrapKey,
++                  events::SYNC_VAULT_PROVIDER_ON_WRAP_KEY_REQUESTED,
++                  provider_api::OnWrapKeyRequested::kEventName,
++                  provider_api::OnWrapKeyRequested::Create(request),
++                  std::move(callback));
++}
++
++SyncVaultProviderService::RequestId SyncVaultProviderService::UnwrapKey(
++    const std::string& vault_uuid,
++    std::vector<uint8_t> key_envelope,
++    ResponseCallback callback) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  const Extension* provider = GetSelectedProvider();
++  const SyncVaultProviderInfo* info =
++      provider ? SyncVaultProviderInfo::Get(provider) : nullptr;
++  if (!info || !info->account_key()) {
++    std::move(callback).Run(base::unexpected(
++        MakeFailure(0, provider_api::SyncVaultProviderError::kUnsupported)));
++    return 0;
++  }
++  if (!IsValidVaultUuid(vault_uuid) || key_envelope.empty() ||
++      key_envelope.size() > syncer::kSyncVaultMaximumEncryptedObjectBytes) {
++    std::move(callback).Run(base::unexpected(
++        MakeFailure(0, provider_api::SyncVaultProviderError::kInvalidData)));
++    return 0;
++  }
++  provider_api::UnwrapKeyRequest request;
++  request.request_id = NewRequestId();
++  request.vault_uuid = vault_uuid;
++  request.key_envelope = std::move(key_envelope);
++  return Dispatch(request.request_id, RequestType::kUnwrapKey,
++                  events::SYNC_VAULT_PROVIDER_ON_UNWRAP_KEY_REQUESTED,
++                  provider_api::OnUnwrapKeyRequested::kEventName,
++                  provider_api::OnUnwrapKeyRequested::Create(request),
++                  std::move(callback));
++}
++
++void SyncVaultProviderService::CancelRequest(RequestId request_id) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  auto it = pending_requests_.find(request_id);
++  if (it == pending_requests_.end()) {
++    return;
++  }
++  if (it->second.type == RequestType::kConfigure) {
++    active_configuration_request_id_.reset();
++  }
++  ResponseCallback callback = std::move(it->second.callback);
++  pending_requests_.erase(it);
++  DispatchCancellation(request_id);
++  std::move(callback).Run(base::unexpected(
++      MakeFailure(request_id, provider_api::SyncVaultProviderError::kAborted)));
++}
++
 +void SyncVaultProviderService::AddObserver(Observer* observer) {
 +  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
 +  observers_.AddObserver(observer);
@@ -120,10 +446,129 @@
 +  observers_.RemoveObserver(observer);
 +}
 +
++base::WeakPtr<SyncVaultProviderService> SyncVaultProviderService::GetWeakPtr() {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  return weak_ptr_factory_.GetWeakPtr();
++}
++
 +void SyncVaultProviderService::Shutdown() {
 +  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  shutting_down_ = true;
 +  registry_observation_.Reset();
++  auto fail_pending =
++      CancelPendingRequests(provider_api::SyncVaultProviderError::kAborted);
 +  selected_provider_id_.reset();
++  std::move(fail_pending).Run();
++}
++
++SyncVaultProviderService::RequestId SyncVaultProviderService::Dispatch(
++    RequestId request_id,
++    RequestType type,
++    events::HistogramValue histogram_value,
++    const std::string& event_name,
++    base::ListValue event_args,
++    ResponseCallback callback,
++    size_t maximum_response_bytes) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  if (shutting_down_) {
++    std::move(callback).Run(base::unexpected(MakeFailure(
++        request_id, provider_api::SyncVaultProviderError::kAborted)));
++    return 0;
++  }
++  const Extension* provider = GetSelectedProvider();
++  if (!provider) {
++    std::move(callback).Run(base::unexpected(MakeFailure(
++        request_id, provider_api::SyncVaultProviderError::kAccessDenied)));
++    return 0;
++  }
++  if (!event_router_->ExtensionHasEventListener(provider->id(), event_name)) {
++    std::move(callback).Run(base::unexpected(MakeFailure(
++        request_id, provider_api::SyncVaultProviderError::kUnsupported)));
++    return 0;
++  }
++  const bool inserted =
++      pending_requests_
++          .emplace(request_id, PendingRequest{type, std::move(callback),
++                                              maximum_response_bytes})
++          .second;
++  CHECK(inserted);
++  auto event = std::make_unique<Event>(histogram_value, event_name,
++                                       std::move(event_args), browser_context_);
++  event_router_->DispatchEventToExtension(provider->id(), std::move(event));
++  return request_id;
++}
++
++void SyncVaultProviderService::DispatchRelease(
++    events::HistogramValue histogram_value,
++    const std::string& event_name,
++    base::ListValue event_args) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  const Extension* provider = GetSelectedProvider();
++  if (!provider ||
++      !event_router_->ExtensionHasEventListener(provider->id(), event_name)) {
++    return;
++  }
++  event_router_->DispatchEventToExtension(
++      provider->id(),
++      std::make_unique<Event>(histogram_value, event_name,
++                              std::move(event_args), browser_context_));
++}
++
++void SyncVaultProviderService::DispatchCancellation(RequestId request_id) {
++  provider_api::RequestCancellation cancellation;
++  cancellation.request_id = request_id;
++  DispatchRelease(events::SYNC_VAULT_PROVIDER_ON_CANCEL_REQUESTED,
++                  provider_api::OnCancelRequested::kEventName,
++                  provider_api::OnCancelRequested::Create(cancellation));
++}
++
++SyncVaultProviderService::RequestId SyncVaultProviderService::NewRequestId() {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  while (pending_requests_.contains(next_request_id_) ||
++         active_configuration_request_id_ == next_request_id_) {
++    next_request_id_ = next_request_id_ == std::numeric_limits<RequestId>::max()
++                           ? 1
++                           : next_request_id_ + 1;
++  }
++  const RequestId result = next_request_id_;
++  next_request_id_ =
++      result == std::numeric_limits<RequestId>::max() ? 1 : result + 1;
++  return result;
++}
++
++base::OnceClosure SyncVaultProviderService::CancelPendingRequests(
++    provider_api::SyncVaultProviderError error) {
++  const std::optional<RequestId> configuration_to_cancel =
++      active_configuration_request_id_;
++  auto pending = std::move(pending_requests_);
++  pending_requests_.clear();
++  active_configuration_request_id_.reset();
++  if (configuration_to_cancel && !pending.contains(*configuration_to_cancel)) {
++    DispatchCancellation(*configuration_to_cancel);
++  }
++  for (const auto& [request_id, request] : pending) {
++    DispatchCancellation(request_id);
++  }
++  // The caller updates selection state before running these callbacks.
++  return base::BindOnce(
++      [](std::map<RequestId, PendingRequest> pending,
++         provider_api::SyncVaultProviderError error) {
++        for (auto& [request_id, request] : pending) {
++          std::move(request.callback)
++              .Run(base::unexpected(
++                  ProviderFailure{request_id, error, std::nullopt}));
++        }
++      },
++      std::move(pending), error);
++}
++
++SyncVaultProviderService::ProviderFailure SyncVaultProviderService::MakeFailure(
++    RequestId request_id,
++    provider_api::SyncVaultProviderError error) const {
++  ProviderFailure failure;
++  failure.request_id = request_id;
++  failure.error = error;
++  return failure;
 +}
 +
 +void SyncVaultProviderService::OnExtensionLoaded(
@@ -144,9 +589,12 @@
 +    UnloadedExtensionReason reason) {
 +  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
 +  if (selected_provider_id_ && *selected_provider_id_ == extension->id()) {
++    auto fail_pending =
++        CancelPendingRequests(provider_api::SyncVaultProviderError::kAborted);
 +    for (Observer& observer : observers_) {
 +      observer.OnSyncVaultProviderAvailabilityChanged(false);
 +    }
++    std::move(fail_pending).Run();
 +  }
 +}
 +
@@ -168,6 +616,7 @@
 +    : ProfileKeyedServiceFactory(
 +          "SyncVaultProviderService",
 +          ProfileSelections::BuildRedirectedInIncognito()) {
++  DependsOn(EventRouterFactory::GetInstance());
 +  DependsOn(ExtensionRegistryFactory::GetInstance());
 +}
 +
@@ -182,7 +631,7 @@
 +}  // namespace extensions
 --- /dev/null
 +++ b/chrome/browser/extensions/api/sync_vault_provider/sync_vault_provider_service.h
-@@ -0,0 +1,99 @@
+@@ -0,0 +1,215 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
@@ -190,17 +639,26 @@
 +#ifndef CHROME_BROWSER_EXTENSIONS_API_SYNC_VAULT_PROVIDER_SYNC_VAULT_PROVIDER_SERVICE_H_
 +#define CHROME_BROWSER_EXTENSIONS_API_SYNC_VAULT_PROVIDER_SYNC_VAULT_PROVIDER_SERVICE_H_
 +
++#include <cstdint>
++#include <map>
 +#include <memory>
 +#include <optional>
++#include <string>
 +#include <vector>
 +
++#include "base/functional/callback_forward.h"
 +#include "base/memory/raw_ptr.h"
++#include "base/memory/weak_ptr.h"
 +#include "base/no_destructor.h"
 +#include "base/observer_list.h"
 +#include "base/scoped_observation.h"
 +#include "base/sequence_checker.h"
++#include "base/types/expected.h"
++#include "base/values.h"
 +#include "chrome/browser/profiles/profile_keyed_service_factory.h"
++#include "chrome/common/extensions/api/sync_vault_provider.h"
 +#include "components/keyed_service/core/keyed_service.h"
++#include "extensions/browser/extension_event_histogram_value.h"
 +#include "extensions/browser/extension_registry_observer.h"
 +#include "extensions/common/extension_id.h"
 +
@@ -210,12 +668,42 @@
 +
 +namespace extensions {
 +
++class EventRouter;
 +class Extension;
 +class ExtensionRegistry;
 +
 +class SyncVaultProviderService : public KeyedService,
 +                                 public ExtensionRegistryObserver {
 + public:
++  using RequestId = int;
++  using ProviderResponse = api::sync_vault_provider::ProviderResponse;
++  struct ProviderFailure {
++    RequestId request_id;
++    api::sync_vault_provider::SyncVaultProviderError error;
++    std::optional<std::string> provider_message;
++  };
++  using Response = base::expected<ProviderResponse, ProviderFailure>;
++  using ResponseCallback = base::OnceCallback<void(Response)>;
++
++  // Owns one provider configuration lifecycle. Destroying an unfinished
++  // session cancels both the initial request and any asynchronous continuation.
++  class ConfigurationSession {
++   public:
++    ~ConfigurationSession();
++
++    ConfigurationSession(const ConfigurationSession&) = delete;
++    ConfigurationSession& operator=(const ConfigurationSession&) = delete;
++
++   private:
++    friend class SyncVaultProviderService;
++
++    ConfigurationSession(base::WeakPtr<SyncVaultProviderService> service,
++                         RequestId request_id);
++
++    base::WeakPtr<SyncVaultProviderService> service_;
++    const RequestId request_id_;
++  };
++
 +  class Observer : public base::CheckedObserver {
 +   public:
 +    virtual void OnSyncVaultProviderSelectionChanged(
@@ -240,13 +728,83 @@
 +    return selected_provider_id_;
 +  }
 +
++  [[nodiscard]] std::unique_ptr<ConfigurationSession> Configure(
++      ResponseCallback callback);
++  RequestId ListVaults(ResponseCallback callback);
++  RequestId CreateVault(const std::string& vault_uuid,
++                        const std::string& display_name,
++                        ResponseCallback callback);
++  RequestId RenameVault(const std::string& vault_uuid,
++                        const std::string& display_name,
++                        ResponseCallback callback);
++  RequestId ReadObject(const std::string& vault_uuid,
++                       const std::string& object_id,
++                       int max_bytes,
++                       ResponseCallback callback);
++  RequestId WriteObject(const std::string& vault_uuid,
++                        const std::string& object_id,
++                        std::vector<uint8_t> data,
++                        std::optional<std::string> expected_revision,
++                        std::optional<int> retention_epoch,
++                        ResponseCallback callback);
++  RequestId CollectEpochs(const std::string& vault_uuid,
++                          int minimum_retained_epoch,
++                          ResponseCallback callback);
++  RequestId WrapKey(const std::string& vault_uuid,
++                    std::vector<uint8_t> vault_key,
++                    ResponseCallback callback);
++  RequestId UnwrapKey(const std::string& vault_uuid,
++                      std::vector<uint8_t> key_envelope,
++                      ResponseCallback callback);
++  void CancelRequest(RequestId request_id);
++
 +  void AddObserver(Observer* observer);
 +  void RemoveObserver(Observer* observer);
++
++  base::WeakPtr<SyncVaultProviderService> GetWeakPtr();
 +
 +  // KeyedService:
 +  void Shutdown() override;
 +
 + private:
++  enum class RequestType {
++    kConfigure,
++    kListVaults,
++    kCreateVault,
++    kRenameVault,
++    kReadObject,
++    kWriteObject,
++    kCollectEpochs,
++    kWrapKey,
++    kUnwrapKey,
++    kMaxValue = kUnwrapKey,
++  };
++
++  struct PendingRequest {
++    RequestType type;
++    ResponseCallback callback;
++    size_t maximum_response_bytes = 0;
++  };
++
++  RequestId Dispatch(RequestId request_id,
++                     RequestType type,
++                     events::HistogramValue histogram_value,
++                     const std::string& event_name,
++                     base::ListValue event_args,
++                     ResponseCallback callback,
++                     size_t maximum_response_bytes = 0);
++  void DispatchRelease(events::HistogramValue histogram_value,
++                       const std::string& event_name,
++                       base::ListValue event_args);
++  void DispatchCancellation(RequestId request_id);
++  void CancelConfiguration(RequestId request_id);
++  RequestId NewRequestId();
++  [[nodiscard]] base::OnceClosure CancelPendingRequests(
++      api::sync_vault_provider::SyncVaultProviderError error);
++  ProviderFailure MakeFailure(
++      RequestId request_id,
++      api::sync_vault_provider::SyncVaultProviderError error) const;
++
 +  // ExtensionRegistryObserver:
 +  void OnExtensionLoaded(content::BrowserContext* browser_context,
 +                         const Extension* extension) override;
@@ -254,13 +812,20 @@
 +                           const Extension* extension,
 +                           UnloadedExtensionReason reason) override;
 +
++  raw_ptr<content::BrowserContext> browser_context_;
++  raw_ptr<EventRouter> event_router_;
 +  raw_ptr<ExtensionRegistry> extension_registry_;
 +  std::optional<ExtensionId> selected_provider_id_;
++  bool shutting_down_ = false;
++  std::optional<RequestId> active_configuration_request_id_;
++  std::map<RequestId, PendingRequest> pending_requests_;
++  RequestId next_request_id_ = 1;
 +  base::ObserverList<Observer> observers_;
 +  base::ScopedObservation<ExtensionRegistry, ExtensionRegistryObserver>
 +      registry_observation_{this};
 +
 +  SEQUENCE_CHECKER(sequence_checker_);
++  base::WeakPtrFactory<SyncVaultProviderService> weak_ptr_factory_{this};
 +};
 +
 +class SyncVaultProviderServiceFactory : public ProfileKeyedServiceFactory {

--- a/patches/helium/core/sync/vault-format.patch
+++ b/patches/helium/core/sync/vault-format.patch
@@ -621,7 +621,7 @@
 +#endif  // COMPONENTS_SYNC_ENGINE_SYNC_VAULT_SYNC_VAULT_FORMAT_H_
 --- /dev/null
 +++ b/components/sync/engine/sync_vault/sync_vault_limits.h
-@@ -0,0 +1,27 @@
+@@ -0,0 +1,36 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
@@ -630,6 +630,7 @@
 +#define COMPONENTS_SYNC_ENGINE_SYNC_VAULT_SYNC_VAULT_LIMITS_H_
 +
 +#include <cstddef>
++#include <string_view>
 +
 +namespace syncer {
 +
@@ -645,6 +646,14 @@
 +inline constexpr size_t kSyncVaultMaximumEntityPlaintextBytes =
 +    kSyncVaultMaximumEncryptedObjectBytes - kSyncVaultContainerOverheadBytes;
 +inline constexpr size_t kSyncVaultMaximumReconstructedBytes = 256 * 1024 * 1024;
++
++inline constexpr bool IsValidSyncVaultObjectId(std::string_view value) {
++  return !value.empty() && value.size() <= kSyncVaultMaximumIdentifierBytes;
++}
++
++inline constexpr bool IsValidSyncVaultRevision(std::string_view value) {
++  return !value.empty() && value.size() <= kSyncVaultMaximumIdentifierBytes;
++}
 +
 +}  // namespace syncer
 +

--- a/patches/series
+++ b/patches/series
@@ -130,7 +130,7 @@ helium/core/sync/vault-store.patch
 helium/core/sync/loopback-server-in-memory.patch
 helium/core/sync/history-expiration-threshold.patch
 helium/core/sync/vault-engine-backend.patch
-helium/core/sync/provider/api-contract.patch
+helium/core/sync/provider/api.patch
 helium/core/sync/provider/manifest-handler.patch
 helium/core/sync/provider/service.patch
 helium/core/sync/provider/profile-prefs.patch


### PR DESCRIPTION
- connect the provider API to the profile service so the browser can request vault operations and extensions can return results
- match responses to pending requests, validate their contents, and handle provider state changes and asynchronous configuration
- limit outstanding requests, time out unanswered requests, and keep service workers alive while handling them

Related: #90