### PR TITLE
helium/ui: prettify the fullscreen notice, cut visible time

### DIFF
--- a/patches/helium/ui/exclusive-access-bubble.patch
+++ b/patches/helium/ui/exclusive-access-bubble.patch
@@ -1,0 +1,134 @@
+--- a/chrome/browser/ui/exclusive_access/exclusive_access_bubble.h
++++ b/chrome/browser/ui/exclusive_access/exclusive_access_bubble.h
+@@ -29,7 +29,7 @@ class ExclusiveAccessBubble {
+   const ExclusiveAccessBubbleParams& params() const { return params_; }
+ 
+   // Time the bubble is shown before hiding automatically.
+-  static constexpr base::TimeDelta kShowTime = base::Milliseconds(3800);
++  static constexpr base::TimeDelta kShowTime = base::Milliseconds(2500);
+   // Time without user input that must elapse before the bubble is re-shown.
+   static constexpr base::TimeDelta kSnoozeTime = base::Minutes(15);
+ 
+--- a/chrome/browser/ui/views/exclusive_access/exclusive_access_bubble_views.cc
++++ b/chrome/browser/ui/views/exclusive_access/exclusive_access_bubble_views.cc
+@@ -400,7 +400,7 @@ void ExclusiveAccessBubbleViews::Hide()
+   RunHideCallbackIfNeeded(ExclusiveAccessBubbleHideReason::kTimeout);
+   presentation_cb_.Reset();
+ 
+-  animation_->SetSlideDuration(base::Milliseconds(700));
++  animation_->SetSlideDuration(base::Milliseconds(300));
+   animation_->Hide();
+ }
+ 
+@@ -408,7 +408,7 @@ void ExclusiveAccessBubbleViews::Show()
+   if (animation_->IsShowing()) {
+     return;
+   }
+-  animation_->SetSlideDuration(base::Milliseconds(350));
++  animation_->SetSlideDuration(base::Milliseconds(300));
+   animation_->Show();
+ 
+ #if !BUILDFLAG(IS_MAC)
+--- a/components/fullscreen_control/subtle_notification_view.cc
++++ b/components/fullscreen_control/subtle_notification_view.cc
+@@ -30,33 +30,33 @@
+ #include "ui/views/widget/widget.h"
+ namespace {
+ 
++const int kBubbleCornerRadius = 12;
++
+ // Space between the site info label.
+ const int kMiddlePaddingPx = 30;
+ 
+-const int kOuterPaddingHorizPx = 40;
++const int kOuterPaddingHorizPx = 16;
+ const int kOuterPaddingVertPx = 8;
+ 
+ // Spacing around the key name.
+-const int kKeyNameMarginHorizPx = 7;
++const int kKeyNameMarginHorizPx = 4;
+ const int kKeyNameBorderPx = 1;
+-const int kKeyNameCornerRadius = 2;
+-const int kKeyNamePaddingPx = 5;
++const int kKeyNameCornerRadius = 6;
++const int kKeyNamePaddingVertPx = 2;
++const int kKeyNamePaddingHorizPx = 4;
+ 
+ // Spacing between the key name and image, if any.
+ const int kKeyNameImageSpacingPx = 3;
+ 
+-// The context used to obtain typography for the instruction text. It's not
+-// really a dialog, but a dialog title is a good fit.
+-constexpr int kInstructionTextContext = views::style::CONTEXT_DIALOG_TITLE;
++// The context used to obtain typography for the instruction text.
++constexpr int kInstructionTextContext = views::style::CONTEXT_DIALOG_BODY_TEXT;
+ 
+ // Delimiter indicating there should be a segment displayed as a keyboard key.
+ constexpr char16_t kKeyNameDelimiter[] = u"|";
+ 
+ // Returns the background color to use for the notification.
+ ui::ColorId GetSubtleNotificationBackgroundColor() {
+-  return base::FeatureList::IsEnabled(features::kFullscreenBubbleShowOpaque)
+-             ? color::kFullscreenNotificationOpaqueBackgroundColor
+-             : color::kFullscreenNotificationTransparentBackgroundColor;
++  return color::kFullscreenNotificationOpaqueBackgroundColor;
+ }
+ 
+ }  // namespace
+@@ -162,6 +162,11 @@ void SubtleNotificationView::Instruction
+     const std::u16string& text,
+     bool format_as_key,
+     std::unique_ptr<views::View> key_image) {
++  // Avoid extra trailing spacing if there are no trailing items.
++  if (!format_as_key && text.empty()) {
++    return;
++  }
++
+   constexpr SkColor kForegroundColor = SK_ColorWHITE;
+ 
+   views::Label* label = new views::Label(text, kInstructionTextContext);
+@@ -175,11 +180,15 @@ void SubtleNotificationView::Instruction
+   }
+ 
+   views::View* key = new views::View;
++  // Use the font's vertical whitespace for the border, keeping the text offset.
+   auto key_name_layout = std::make_unique<views::BoxLayout>(
+       views::BoxLayout::Orientation::kHorizontal,
+-      gfx::Insets::VH(0, kKeyNamePaddingPx), kKeyNameImageSpacingPx);
++      gfx::Insets::TLBR(-kKeyNameBorderPx, kKeyNamePaddingHorizPx,
++                        kKeyNamePaddingVertPx - kKeyNameBorderPx,
++                        kKeyNamePaddingHorizPx),
++      kKeyNameImageSpacingPx);
+   key_name_layout->set_minimum_cross_axis_size(
+-      label->GetPreferredSize({}).height() + kKeyNamePaddingPx * 2);
++      label->GetPreferredSize({}).height());
+   key->SetLayoutManager(std::move(key_name_layout));
+   if (key_image)
+     key->AddChildView(std::move(key_image));
+@@ -205,6 +214,7 @@ SubtleNotificationView::SubtleNotificati
+   auto bubble_border = std::make_unique<views::BubbleBorder>(
+       views::BubbleBorder::NONE, views::BubbleBorder::NO_SHADOW);
+   bubble_border->SetColor(GetSubtleNotificationBackgroundColor());
++  bubble_border->set_rounded_corners(gfx::RoundedCornersF(kBubbleCornerRadius));
+   SetBackground(std::make_unique<views::BubbleBackground>(bubble_border.get()));
+   SetBorder(std::move(bubble_border));
+ 
+@@ -265,6 +275,7 @@ views::Widget* SubtleNotificationView::C
+ #endif
+ 
+   params.opacity = views::Widget::InitParams::WindowOpacity::kTranslucent;
++  params.shadow_type = views::Widget::InitParams::ShadowType::kNone;
+   params.z_order = ui::ZOrderLevel::kSecuritySurface;
+   params.accept_events = false;
+   popup->Init(std::move(params));
+--- a/components/fullscreen_control/color_mixer.cc
++++ b/components/fullscreen_control/color_mixer.cc
+@@ -16,7 +16,7 @@ void AddColorMixer(ui::ColorProvider* pr
+                    const ui::ColorProviderKey& key) {
+   ui::ColorMixer& mixer = provider->AddMixer();
+   mixer[color::kFullscreenNotificationOpaqueBackgroundColor] = {
+-      SkColorSetRGB(0x28, 0x2c, 0x32)};
++      SkColorSetRGB(0x30, 0x30, 0x30)};
+   mixer[color::kFullscreenNotificationTransparentBackgroundColor] = {
+       ui::SetAlpha(color::kFullscreenNotificationOpaqueBackgroundColor, 0xcc)};
+ }

--- a/patches/series
+++ b/patches/series
@@ -356,3 +356,4 @@ helium/ui/helium-noise-page-info.patch
 helium/ui/show-tabs-from-non-account-backends.patch
 helium/ui/compact-debugger-warning.patch
 helium/ui/progress-bar.patch
+helium/ui/exclusive-access-bubble.patch


### PR DESCRIPTION
- the bubble stays on screen for 1.7 seconds less (~4.5s before, ~2.8s now) and fade out animation is no longer frustrating.
- the action key is now smaller and no longer bleeds trailing margin when no trailing elements are visible.
- the action key is now smaller.
- the bubble no longer draws system border+shadow on macOS and looks the same across platforms.
- the background is no longer blue-ish.
- overall, the bubble is more compact, and has a round background to fit the rest of helium ui.

closes #2465

before and after:
<img width="495" height="154" alt="exclusive" src="https://github.com/user-attachments/assets/08f1825e-7662-4bad-820e-7d534cce8af5" />


before:

https://github.com/user-attachments/assets/0033521a-2f4f-4ad1-a3cb-966a9bf32bbc


after:

https://github.com/user-attachments/assets/f18de17f-fc23-47da-af44-99f00868094f


