### PR TITLE
helium/ui: fix minor frame issues

### DIFF
--- a/patches/helium/ui/helium-color-mixers.patch
+++ b/patches/helium/ui/helium-color-mixers.patch
@@ -20,19 +20,18 @@
    mixer[kColorToolbarButtonBackgroundHighlightedDefault] = {
        ui::kColorSysStateHoverOnSubtle};
    mixer[kColorToolbarButtonBorder] = {ui::kColorSysOutline};
-@@ -487,7 +491,10 @@ void AddMaterialChromeColorMixer(ui::Col
+@@ -487,7 +491,9 @@ void AddMaterialChromeColorMixer(ui::Col
        {ui::kColorSysStateDisabled}, {kColorToolbar})};
    mixer[kColorToolbarButtonIconPressed] = {kColorToolbarButtonIconHovered};
    mixer[kColorToolbarButtonText] = {ui::kColorSysOnSurfaceSecondary};
 -  mixer[kColorToolbarContentAreaSeparator] = {ui::kColorSysSurfaceVariant};
 +  mixer[kColorToolbarContentAreaSeparator] = {
-+      dark_mode ? ui::GetResultingPaintColor({ui::kColorSysStateHoverOnSubtle},
-+                                             {kColorToolbar})
++      dark_mode ? ui::kColorSysStateHoverOnSubtle
 +                : ui::kColorSysSurfaceVariant};
    mixer[kColorToolbarFeaturePromoHighlight] = {ui::kColorSysPrimary};
    mixer[kColorToolbarIconContainerBorder] = {ui::kColorSysNeutralOutline};
    mixer[kColorToolbarInkDropHover] = {ui::kColorSysStateHoverOnSubtle};
-@@ -496,8 +503,11 @@ void AddMaterialChromeColorMixer(ui::Col
+@@ -496,8 +502,11 @@ void AddMaterialChromeColorMixer(ui::Col
    mixer[kColorToolbarExtensionSeparatorDisabled] = {
        kColorToolbarButtonIconInactive};
    mixer[kColorToolbarSeparator] = {kColorToolbarSeparatorDefault};
@@ -47,7 +46,7 @@
    mixer[kColorToolbarTextDisabled] = {kColorToolbarTextDisabledDefault};
 --- a/chrome/browser/ui/color/chrome_color_mixer.cc
 +++ b/chrome/browser/ui/color/chrome_color_mixer.cc
-@@ -119,9 +119,13 @@ ui::ColorTransform GetToolbarTopSeparato
+@@ -119,9 +119,17 @@ ui::ColorTransform GetToolbarTopSeparato
  // Apply updates to the Omnibox background color tokens per GM3 spec.
  void ApplyGM3OmniboxBackgroundColor(ui::ColorMixer& mixer,
                                      const ui::ColorProviderKey& key) {
@@ -56,22 +55,25 @@
    // Apply omnibox background color updates only to non-themed clients.
    if (!key.custom_theme) {
 -    mixer[kColorLocationBarBackground] = {ui::kColorSysOmniboxContainer};
-+    mixer[kColorLocationBarBackground] = {
++    // Let frame materials show through the location bar and its matching tabs.
++    const SkAlpha background_alpha =
++        ShouldApplyHighContrastColors(key) ? SK_AlphaOPAQUE : 0xCC;
++    mixer[kColorLocationBarBackground] = ui::SetAlpha(
 +        dark_mode ? ui::ColorTransform(kColorOmniboxResultsBackground)
-+                  : ui::ColorTransform(ui::kColorSysOmniboxContainer)};
++                  : ui::ColorTransform(ui::kColorSysOmniboxContainer),
++        background_alpha);
      mixer[kColorLocationBarBackgroundHovered] =
          ui::GetResultingPaintColor(ui::kColorSysStateHoverBrightBlendProtection,
                                     kColorLocationBarBackground);
-@@ -779,8 +783,10 @@ void AddChromeColorMixer(ui::ColorProvid
+@@ -779,8 +787,9 @@ void AddChromeColorMixer(ui::ColorProvid
        ui::SetAlpha(kColorToolbarButtonIcon, gfx::kGoogleGreyAlpha500)};
    mixer[kColorToolbarButtonIconPressed] = {kColorToolbarButtonIconHovered};
    mixer[kColorToolbarButtonText] = ui::GetColorWithMaxContrast(kColorToolbar);
 -  mixer[kColorToolbarContentAreaSeparator] =
 -      ui::AlphaBlend(kColorToolbarButtonIcon, kColorToolbar, 0x3A);
-+  mixer[kColorToolbarContentAreaSeparator] = {
-+      dark_mode ? ui::GetResultingPaintColor({ui::kColorSysStateHoverOnSubtle},
-+                                             {kColorToolbar})
-+                : ui::kColorSysSurfaceVariant};
++  mixer[kColorToolbarContentAreaSeparator] = {ui::kColorSysStateHoverOnSubtle};
++  mixer[kColorToolbarContentAreaSeparatorSolid] = ui::GetResultingPaintColor(
++      kColorToolbarContentAreaSeparator, kColorToolbar);
    mixer[kColorToolbarFeaturePromoHighlight] =
        ui::PickGoogleColor(ui::kColorAccent, kColorToolbar,
                            color_utils::kMinimumVisibleContrastRatio);
@@ -226,3 +228,27 @@
  
    // TODO(crbug.com/517162116): Reconcile color token dark-mode swapping
    // These tokens are temporarily added to solve a missing need. They need
+--- a/chrome/browser/ui/color/chrome_color_id.h
++++ b/chrome/browser/ui/color/chrome_color_id.h
+@@ -1092,6 +1092,7 @@
+   E_CPONLY(kColorToolbarButtonText) \
+   E_CPONLY(kColorToolbarCloseButtonBackgroundDefault) \
+   E_CPONLY(kColorToolbarContentAreaSeparator) \
++  E_CPONLY(kColorToolbarContentAreaSeparatorSolid) \
+   E_CPONLY(kColorToolbarContextualTasksButtonShadow) \
+   E_CPONLY(kColorToolbarExtensionSeparatorDisabled) \
+   E_CPONLY(kColorToolbarExtensionSeparatorEnabled) \
+--- a/chrome/browser/ui/views/frame/contents_separator.cc
++++ b/chrome/browser/ui/views/frame/contents_separator.cc
+@@ -29,9 +29,9 @@ ContentsSeparator::CreateContentsSeparat
+ 
+ ContentsSeparator::ContentsSeparator(bool create_layer) {
+   SetBackground(create_layer ? views::CreateLayerBasedSolidBackground(
+-                                   kColorToolbarContentAreaSeparator)
++                                   kColorToolbarContentAreaSeparatorSolid)
+                              : views::CreateSolidBackground(
+-                                   kColorToolbarContentAreaSeparator));
++                                   kColorToolbarContentAreaSeparatorSolid));
+ 
+   // BrowserViewLayout will respect either the height or width of this,
+   // depending on orientation, not simultaneously both.

--- a/patches/helium/ui/layout/zen-mode.patch
+++ b/patches/helium/ui/layout/zen-mode.patch
@@ -1945,8 +1945,8 @@
    round_bottom_left_window_corner_ = round_bottom_left;
    round_bottom_right_window_corner_ = round_bottom_right;
  
-@@ -229,8 +235,7 @@ void ContentsContainerView::UpdateBorder
-         SetBorder(nullptr);
+@@ -231,8 +237,7 @@ void ContentsContainerView::UpdateBorder
+             gfx::Insets(ContentsContainerOutline::kThickness)));
        }
      }
 -    if (split_changed || rounded_contents_changed ||
@@ -1955,7 +1955,7 @@
        UpdateBorderRoundedCorners();
      }
  
-@@ -338,12 +343,17 @@ void ContentsContainerView::UpdateBorder
+@@ -340,13 +345,18 @@ void ContentsContainerView::UpdateBorder
        round_bottom_left_window_corner_ ? frame_radius : generic_radius;
    const int lower_right_radius =
        round_bottom_right_window_corner_ ? frame_radius : generic_radius;
@@ -1968,7 +1968,8 @@
 -      generic_radius, generic_radius, lower_right_radius, lower_left_radius);
 +      upper_left_radius, upper_right_radius, lower_right_radius,
 +      lower_left_radius);
-   const int inner_padding = is_in_split_ ? kSplitViewContentPadding : 0;
+   const int inner_padding = is_in_split_ ? kSplitViewContentPadding
+                                          : ContentsContainerOutline::kThickness;
    const gfx::RoundedCornersF inner_rounded_corners(
 -      generic_radius - inner_padding, generic_radius - inner_padding,
 +      upper_left_radius - inner_padding, upper_right_radius - inner_padding,

--- a/patches/helium/ui/location-bar.patch
+++ b/patches/helium/ui/location-bar.patch
@@ -192,6 +192,18 @@
    gfx::Rect bounds_without_endcaps(GetLocalBounds());
    bounds_without_endcaps.Inset(gfx::Insets::VH(0, border_radius));
    return bounds_without_endcaps;
+@@ -1491,9 +1515,8 @@ void LocationBarView::RefreshBackground(
+         /*antialias=*/true, /*should_border_scale=*/true));
+   }
+ 
+-  // Keep the views::Textfield in sync. It needs an opaque background to
+-  // correctly enable subpixel AA.
+-  omnibox_view_->SetBackgroundColor(background_color_);
++  // The location bar already paints the background behind the text field.
++  omnibox_view_->SetBackgroundColor(SK_ColorTRANSPARENT);
+ 
+   // The divider between indicators and request chips should have the same color
+   // as the omnibox.
 --- a/chrome/browser/ui/views/location_bar/location_icon_view.cc
 +++ b/chrome/browser/ui/views/location_bar/location_icon_view.cc
 @@ -111,7 +111,7 @@ SkColor LocationIconView::GetForegroundC

--- a/patches/helium/ui/native-frame-materials.patch
+++ b/patches/helium/ui/native-frame-materials.patch
@@ -1298,7 +1298,7 @@
      bool has_custom_background) const {
 +  if (helium::ShouldUseNativeFrameMaterials(
 +          tab_->controller()->GetBrowserWindowInterface())) {
-+    return selection_state == TabStyle::TabSelectionState::kActive ||
++    return selection_state != TabStyle::TabSelectionState::kInactive ||
 +           GetHoverAnimationValue() > 0.0;
 +  }
 +
@@ -1311,7 +1311,7 @@
        tab()->GetWidget() ? tab()->GetWidget()->ShouldPaintAsActive() : true;
 +  if (helium::ShouldUseNativeFrameMaterials(
 +          tab_->controller()->GetBrowserWindowInterface()) &&
-+      selection_state != TabStyle::TabSelectionState::kActive) {
++      selection_state == TabStyle::TabSelectionState::kInactive) {
 +    const SkColor color = tab_style()->GetTabBackgroundColor(
 +        selection_state, true, frame_active, tab()->GetColorProvider());
 +    return color_utils::AlphaBlend(
@@ -1355,52 +1355,52 @@
  #include "ui/gfx/geometry/insets.h"
  #include "ui/gfx/geometry/rect.h"
  #include "ui/gfx/geometry/rounded_corners_f.h"
-@@ -279,9 +280,18 @@ bool TabView::IsHoverAnimationActive() c
+@@ -279,9 +280,19 @@ bool TabView::IsHoverAnimationActive() c
  }
  
  std::optional<SkColor> TabView::GetBackgroundColor() {
 -  if (active_ || IsHoverAnimationActive() ||
--      should_fill_background_tab_color_) {
--    return GetCurrentTabBackgroundColor(GetSelectionState());
 +  const TabStyle::TabSelectionState selection_state = GetSelectionState();
 +  const bool hover_animation_active = IsHoverAnimationActive();
 +  if (ShouldUseNativeFrameMaterials() &&
-+      selection_state != TabStyle::TabSelectionState::kActive) {
++      selection_state == TabStyle::TabSelectionState::kInactive) {
 +    if (!hover_animation_active) {
 +      return std::nullopt;
 +    }
 +    return GetNativeFrameMaterialTabBackgroundColor(selection_state);
 +  }
 +
-+  if (active_ || hover_animation_active || should_fill_background_tab_color_) {
++  if (active_ || selected_ || hover_animation_active ||
+       should_fill_background_tab_color_) {
+-    return GetCurrentTabBackgroundColor(GetSelectionState());
 +    return GetCurrentTabBackgroundColor(selection_state);
    }
    return std::nullopt;
  }
-@@ -290,6 +300,10 @@ SkColor TabView::GetCurrentTabBackground
+@@ -290,6 +301,10 @@ SkColor TabView::GetCurrentTabBackground
      TabStyle::TabSelectionState selection_state) const {
    const bool frame_active = IsFrameActive();
    const ui::ColorProvider* color_provider = GetColorProvider();
 +  if (ShouldUseNativeFrameMaterials() &&
-+      selection_state != TabStyle::TabSelectionState::kActive) {
++      selection_state == TabStyle::TabSelectionState::kInactive) {
 +    return GetNativeFrameMaterialTabBackgroundColor(selection_state);
 +  }
    const auto* controller =
        collection_node_ ? collection_node_->GetController() : nullptr;
    const bool frame_glass = controller && controller->IsGlassFrame();
-@@ -609,6 +623,11 @@ bool TabView::ShouldPaintTabBackgroundCo
+@@ -609,6 +624,11 @@ bool TabView::ShouldPaintTabBackgroundCo
      TabStyle::TabSelectionState selection_state,
      bool has_custom_background,
      bool hovered) const {
 +  if (ShouldUseNativeFrameMaterials()) {
-+    return selection_state == TabStyle::TabSelectionState::kActive ||
++    return selection_state != TabStyle::TabSelectionState::kInactive ||
 +           GetHoverAnimationValue() > 0.0;
 +  }
 +
    if (selection_state == TabStyle::TabSelectionState::kActive) {
      return true;
    }
-@@ -917,7 +936,7 @@ bool TabView::IsApparentlyActive() const
+@@ -917,7 +937,7 @@ bool TabView::IsApparentlyActive() const
    if (active_) {
      return true;
    }
@@ -1409,7 +1409,7 @@
      return GetHoverOpacity() > 0.5f;
    }
    return selected_;
-@@ -1159,6 +1178,13 @@ void TabView::UpdateThemeColors() {
+@@ -1159,6 +1179,13 @@ void TabView::UpdateThemeColors() {
    if (!tab_interface) {
      return;
    }
@@ -1423,7 +1423,7 @@
  
    BrowserFrameView* const browser_frame_view =
        BrowserView::GetBrowserViewForBrowser(
-@@ -1273,6 +1299,25 @@ TabStyle::TabSelectionState TabView::Get
+@@ -1273,6 +1300,25 @@ TabStyle::TabSelectionState TabView::Get
                                : TabStyle::TabSelectionState::kInactive);
  }
  

--- a/patches/helium/ui/progress-bar.patch
+++ b/patches/helium/ui/progress-bar.patch
@@ -684,7 +684,7 @@
    if (contents) {
      page_action_icon_controller_->UpdateWebContents(contents);
    }
-@@ -2042,6 +2060,8 @@ const LocationBarModel* LocationBarView:
+@@ -2041,6 +2059,8 @@ const LocationBarModel* LocationBarView:
  }
  
  void LocationBarView::OnOmniboxFocused() {
@@ -693,7 +693,7 @@
    if (views::FocusRing::Get(this)) {
      views::FocusRing::Get(this)->Refresh();
    }
-@@ -2066,6 +2086,8 @@ void LocationBarView::OpenOmniboxPopup(b
+@@ -2065,6 +2085,8 @@ void LocationBarView::OpenOmniboxPopup(b
  }
  
  void LocationBarView::OnOmniboxBlurred() {

--- a/patches/helium/ui/rounded-frame-corners.patch
+++ b/patches/helium/ui/rounded-frame-corners.patch
@@ -149,7 +149,8 @@
 +      container_outline_->SetVisible(false);
 +    }
      if (capture_contents_border_view_) {
-       capture_contents_border_view_->SetIsInSplit(true);
+-      capture_contents_border_view_->SetIsInSplit(true);
++      capture_contents_border_view_->SetIsInSplit(is_in_split);
      }
    }
  

--- a/patches/helium/ui/rounded-frame-corners.patch
+++ b/patches/helium/ui/rounded-frame-corners.patch
@@ -117,7 +117,7 @@
        SetBorder(nullptr);
        UpdateBorderRoundedCorners();
  
-@@ -217,22 +221,33 @@ void ContentsContainerView::UpdateBorder
+@@ -217,22 +221,35 @@ void ContentsContainerView::UpdateBorder
        }
      }
    } else {
@@ -129,7 +129,9 @@
 +        SetBorder(views::CreateEmptyBorder(gfx::Insets(
 +            kSplitViewContentPadding + ContentsContainerOutline::kThickness)));
 +      } else {
-+        SetBorder(nullptr);
++        // Reserve the stroke inside the container's existing outer margin.
++        SetBorder(views::CreateEmptyBorder(
++            gfx::Insets(ContentsContainerOutline::kThickness)));
 +      }
      }
 -    if (split_changed || bottom_corner_state_changed) {
@@ -157,7 +159,7 @@
      // Ensures correct window rounded corners after updating contents rounded
      // corners in UpdateBorderRoundedCorners().
      GetWidget()->non_client_view()->frame_view()->UpdateWindowRoundedCorners();
-@@ -311,7 +326,7 @@ void ContentsContainerView::SetBorderRou
+@@ -311,7 +328,7 @@ void ContentsContainerView::SetBorderRou
  }
  
  void ContentsContainerView::UpdateBorderRoundedCorners() {
@@ -166,11 +168,12 @@
      SetBorderRoundedCornersFrom(rounded_corner_radii_);
      return;
    }
-@@ -326,11 +341,10 @@ void ContentsContainerView::UpdateBorder
+@@ -326,11 +343,11 @@ void ContentsContainerView::UpdateBorder
  
    const gfx::RoundedCornersF container_rounded_corners(
        generic_radius, generic_radius, lower_right_radius, lower_left_radius);
-+  const int inner_padding = is_in_split_ ? kSplitViewContentPadding : 0;
++  const int inner_padding = is_in_split_ ? kSplitViewContentPadding
++                                         : ContentsContainerOutline::kThickness;
    const gfx::RoundedCornersF inner_rounded_corners(
 -      generic_radius - kSplitViewContentPadding,
 -      generic_radius - kSplitViewContentPadding,
@@ -181,7 +184,7 @@
  
    container_outline_->SetCornerRadii(container_rounded_corners);
    if (capture_contents_border_view_) {
-@@ -341,7 +355,7 @@ void ContentsContainerView::UpdateBorder
+@@ -341,7 +358,7 @@ void ContentsContainerView::UpdateBorder
  
  void ContentsContainerView::ChildVisibilityChanged(View* child) {
    if ((child == new_tab_footer_view_ || child == devtools_web_view_) &&
@@ -190,7 +193,7 @@
      UpdateBorderRoundedCorners();
    }
  }
-@@ -366,7 +380,7 @@ views::View::Views ContentsContainerView
+@@ -366,7 +383,7 @@ views::View::Views ContentsContainerView
  void ContentsContainerView::OnViewBoundsChanged(View* observed_view) {
    if (observed_view == contents_view_) {
      UpdateDevToolsDockedPlacement();


### PR DESCRIPTION
- fix secondary selected tab backgrounds when native frame materials are enabled, accidentally introduced in m152 merge.
  - before:
    <img width="342" height="434" alt="image" src="https://github.com/user-attachments/assets/889b5bec-38ff-4481-ad21-0081c96fc8f8" />
  
  - after:
    <img width="221" height="245" alt="image" src="https://github.com/user-attachments/assets/e66bb889-94ae-4bc9-bc5c-2826346a07df" />

- make mixed colors actually transparent (for native frame materials to slightly bleed through).
  <img width="767" height="79" alt="image" src="https://github.com/user-attachments/assets/feec60e2-af22-477c-a58e-d409b9e28014" />

- draw rounded frame outline outside of web contents.

  - before:
    <img width="132" height="111" alt="image" src="https://github.com/user-attachments/assets/41f8a0f0-e560-474c-9319-b84930857839" />

  - after:
    <img width="111" height="115" alt="image" src="https://github.com/user-attachments/assets/7165638e-12ee-4471-8fe9-f7f14d13bfa9" />

  fixes #1627