### PR TITLE
devutils/check_downloads_ini: fix crash on default invocation

### DIFF
--- a/devutils/check_downloads_ini.py
+++ b/devutils/check_downloads_ini.py
@@ -44,7 +44,7 @@ def main():
     """CLI entrypoint"""
 
     root_dir = Path(__file__).resolve().parent.parent
-    default_downloads_ini = [str(root_dir / 'downloads.ini')]
+    default_downloads_ini = [root_dir / 'downloads.ini']
 
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('-d',


### PR DESCRIPTION
For your pull request to not get closed without review, please confirm that:

- [ ] An issue exists where the maintainers agreed that this should be implemented
      (an approved feature request, or confirmed bug).
- [x] I tested that my contribution works locally, and does not break anything,
      otherwise I have marked my PR as draft.
- [ ] If my contribution is non-trivial, I did not use AI to write most of it.
- [x] I understand that I will be permanently banned from interacting with this
      organization if I lied by checking any of these checkboxes.

Tested on (check one or more):
- [ ] Windows
- [x] macOS
- [ ] Linux

---

this pr fixes a bug that would make `devutils/check_downloads_ini.py` crash when running it without passing any arguments.
the script normally run without passing any arguments would crash with `AttributeError: 'str' object has no attribute 'open'`. this was because the default value for the script had an explicit `str(...)` wrapping. however, the downstrem code in `utils/downloads.py` expects the default to be a `Path` and performs `.open()` on it—method which is available only to `Path` class.

the reason behind this behavior is that argparse's `type=Path` will convert the argument only if passed from the command line, but won't process the `default` value.

in order to fix this, i removed the redundant `str(...)` wrapping so that the default is a `Path` by default.

i have run the script before and after the patch—script crashes before the change and runs successfully with exit code 0 afterwards.

fixes #2473