### PR TITLE
helium/core: enable remote ts and mojo generation

### DIFF
--- a/patches/helium/core/rbe-nativelink-config.patch
+++ b/patches/helium/core/rbe-nativelink-config.patch
@@ -1,6 +1,6 @@
 --- /dev/null
 +++ b/build/config/siso/backend_config/nativelink.star
-@@ -0,0 +1,20 @@
+@@ -0,0 +1,24 @@
 +# -*- bazel-starlark -*-
 +# Copyright 2026 The Helium Authors
 +# You can use, redistribute, and/or modify this source code under
@@ -17,7 +17,92 @@
 +        "large": properties,
 +    }
 +
++def __configs(ctx):
++    return ["remote-generators"]
++
 +backend = module(
 +    "backend",
 +    platform_properties = __platform_properties,
++    configs = __configs,
 +)
+--- a/build/config/siso/config.star
++++ b/build/config/siso/config.star
+@@ -8,6 +8,8 @@ load("@builtin//struct.star", "module")
+ load("./backend_config/backend.star", "backend")
+ 
+ __KNOWN_CONFIG_OPTIONS = [
++    # Enable remote execution of TypeScript/WebUI and Mojo generator rules.
++    "remote-generators",
+     # Indicates that it is for Google Chromium/Chrome build using Google RBE
+     # as REAPI backend and all remote exeuctions are tested/maintained by
+     # Chrome build infra team.
+--- a/build/config/siso/mojo.star
++++ b/build/config/siso/mojo.star
+@@ -10,7 +10,7 @@ load("./config.star", "config")
+ load("./platform.star", "platform")
+ 
+ def __step_config(ctx, step_config):
+-    remote_run = config.get(ctx, "googlechrome")
++    remote_run = config.get(ctx, "googlechrome") or config.get(ctx, "remote-generators")
+ 
+     # mojom_bindings_generator.py will run faster on n2-highmem-8 than
+     # n2-custom-2-3840
+--- a/build/config/siso/typescript_all.star
++++ b/build/config/siso/typescript_all.star
+@@ -21,7 +21,7 @@ __input_deps = {
+ }
+ 
+ def __step_config(ctx, step_config):
+-    remote_run = config.get(ctx, "googlechrome")
++    remote_run = config.get(ctx, "googlechrome") or config.get(ctx, "remote-generators")
+     step_config["input_deps"].update(typescript_all.input_deps)
+ 
+     use_input_root_absolute_path = False
+--- a/build/config/siso/mac.star
++++ b/build/config/siso/mac.star
+@@ -8,10 +8,12 @@ load("@builtin//path.star", "path")
+ load("@builtin//struct.star", "module")
+ load("./clang_mac.star", "clang")
+ load("./config.star", "config")
++load("./devtools_frontend.star", "devtools_frontend")
+ 
+ def __filegroups(ctx):
+     fg = {}
+     fg.update(clang.filegroups(ctx))
++    fg.update(devtools_frontend.filegroups(ctx))
+     return fg
+ 
+ def __codesign(ctx, cmd):
+@@ -60,6 +62,7 @@ __handlers.update(clang.handlers)
+ def __step_config(ctx, step_config):
+     config.check(ctx)
+     step_config = clang.step_config(ctx, step_config)
++    step_config = devtools_frontend.step_config(ctx, step_config)
+     step_config["rules"].extend([
+         {
+             "name": "codesign",
+--- a/build/config/siso/devtools_frontend.star
++++ b/build/config/siso/devtools_frontend.star
+@@ -25,6 +25,13 @@ def __filegroups(ctx):
+     }
+ 
+ def __step_config(ctx, step_config):
++    # The additional remote path supports Node-based tsc, not host esbuild or tsgo.
++    gn_args = gn.args(ctx)
++    remote_typescript = (
++        config.get(ctx, "remote-generators") and
++        gn_args.get("devtools_skip_typecheck") == "false" and
++        gn_args.get("devtools_use_typescript_go", "false") != "true"
++    )
+     step_config["input_deps"].update({
+         "third_party/devtools-frontend/src/scripts/build/typescript/ts_library.py": [
+             "third_party/devtools-frontend/src/node_modules/typescript:typescript",
+@@ -42,7 +49,7 @@ def __step_config(ctx, step_config):
+         {
+             "name": "devtools-frontend/typescript/ts_library",
+             "command_prefix": "python3 ../../third_party/devtools-frontend/src/scripts/build/typescript/ts_library.py",
+-            "remote": config.get(ctx, "default-remote"),
++            "remote": config.get(ctx, "default-remote") or remote_typescript,
+             "output_local": True,
+             "timeout": "2m",
+             "platform_ref": "large",


### PR DESCRIPTION
add a remote-generators siso option and enable it for the nativelink backend so ts/webui/devtools/mojo stuff can be built/generated remotely
