### PR TITLE
.github/feature-request: remove pending label

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Suggest an idea
-labels: ["feat", "pending"]
+labels: ["feat"]
 title: "[FR]: "
 body:
   - type: markdown


### PR DESCRIPTION
i don't think this is really useful at this point, let's just drop it (and probably `approved` too but we need to update our pr template)